### PR TITLE
Adding tests for imputation

### DIFF
--- a/R/parse_iso8601.R
+++ b/R/parse_iso8601.R
@@ -58,17 +58,8 @@ parse_iso8601 <- function(dates) {
   match_m <- match_m[, fields, drop = FALSE]
   storage.mode(match_m) <- "numeric"
 
-  # when year, month, day available calculate week, weekday, yearday
-  i <- !apply(is.na(match_m[, c("year", "month", "day"), drop = FALSE]), 1, any)
-  if (any(i)) {
-    dates <- strptime(apply(match_m[i, c("year", "month", "day"), drop = FALSE], 1, paste, collapse = "-"), format = "%Y-%m-%d")
-    match_m[i, "week"] <- dates$yday %/% 7 + 1
-    match_m[i, "weekday"] <- dates$yday %% 7 + 1
-    match_m[i, "yearday"] <- dates$yday + 1
-  }
-
   # add month, day when week, weekday available
-  i <- !apply(is.na(match_m[, c("year", "week", "weekday"), drop = FALSE]), 1, any)
+  i <- apply(!is.na(match_m[, c("year", "week", "weekday"), drop = FALSE]), 1, all)
   if (any(i)) {
     dates <- strptime(apply(match_m[i, c("year", "week", "weekday"), drop = FALSE], 1, paste, collapse = "-"), format = "%Y-%U-%u")
     match_m[i, "month"] <- dates$mon + 1
@@ -76,7 +67,7 @@ parse_iso8601 <- function(dates) {
   }
 
   # add month, day when yearday available
-  i <- !apply(is.na(match_m[, c("year", "yearday"), drop = FALSE]), 1, any)
+  i <- apply(!is.na(match_m[, c("year", "yearday"), drop = FALSE]), 1, all)
   if (any(i)) {
     dates <- strptime(apply(match_m[i, c("year", "yearday"), drop = FALSE], 1, paste, collapse = "-"), format = "%Y-%j")
     match_m[i, "month"] <- dates$mon + 1

--- a/tests/testthat/setup_test_data.R
+++ b/tests/testthat/setup_test_data.R
@@ -3,8 +3,8 @@ iso8601_dates <- c(
   "2001",
   "2002-03-04",
   "2003-095", # yearday
-  "2004-W13",  # yearweek
-  "2005-W23-2",  # yearweek + weekday
+  "2004-W13",  # yearweek (will preoduce unknown month)
+  "2005-W23-2",  # yearweek and weekday
   "2006-07-08T09",
   "2007-08-09T10:11",
   "2008-09-10T11:12.2169",  # fractional minute

--- a/tests/testthat/test_partial_time_impute.R
+++ b/tests/testthat/test_partial_time_impute.R
@@ -1,0 +1,86 @@
+test_that("impute_time_min populates fields with minimum appropriate data", {
+  expect_equal(impute_time_min(NA), as.parttime(NA))
+
+  expect_equal(impute_time_min("2022")[, "year"], 2022L)
+
+  expect_equal(impute_time_min("2022-02")[, "month"], 2L)
+  expect_equal(impute_time_min("2022")[, "month"], 1L)
+
+  expect_equal(impute_time_min("2022-02")[, "day"], 1L)
+  expect_equal(impute_time_min("2022-02-15")[, "day"], 15L)
+
+  expect_equal(impute_time_min("2022-02-15")[, "hour"], 0L)
+  expect_equal(impute_time_min("2022-02-15 03")[, "hour"], 3L)
+
+  expect_equal(impute_time_min("2022-02-15 03")[, "min"], 0L)
+  expect_equal(impute_time_min("2022-02-15 03:04")[, "min"], 4L)
+
+  expect_equal(impute_time_min("2022-02-15 03:04")[, "sec"], 0L)
+  expect_equal(impute_time_min("2022-02-15 03:04:05")[, "sec"], 5L)
+
+  expect_equal(impute_time_min("2022-02-15 03:04:05")[, "secfrac"], 0L)
+  expect_equal(impute_time_min("2022-02-15 03:04:05.678")[, "secfrac"], 0.678)
+})
+
+test_that("impute_time_* operates on vectors of partial_time", {
+  expect_equal(unname(impute_time_min(c("2022", "2022-02-02"))[, "day"]), c(1, 2))
+  expect_equal(unname(impute_time_min(c(NA, "2022-02-02"))[, "day"]), c(NA, 2))
+
+  expect_equal(unname(impute_time_max(c("2022", "2022-02-02"))[, "day"]), c(31, 2))
+  expect_equal(unname(impute_time_max(c("2022", NA))[, "day"]), c(31, NA))
+})
+
+test_that("impute_time_max populates fields with maximum appropriate data", {
+  expect_equal(impute_time_max(NA), as.parttime(NA))
+
+  expect_equal(impute_time_max("2022")[, "year"], 2022L)
+
+  expect_equal(impute_time_max("2022-02")[, "month"], 2L)
+  expect_equal(impute_time_max("2022")[, "month"], 12L)
+
+  expect_equal(impute_time_max("2024-01")[, "day"], 31L)
+  expect_equal(impute_time_max("2022-02-15")[, "day"], 15L)
+
+  expect_equal(impute_time_max("2022-02-15")[, "hour"], 23L)
+  expect_equal(impute_time_max("2022-02-15 03")[, "hour"], 3L)
+
+  expect_equal(impute_time_max("2022-02-15 03")[, "min"], 59L)
+  expect_equal(impute_time_max("2022-02-15 03:04")[, "min"], 4L)
+
+  expect_equal(impute_time_max("2022-02-15 03:04")[, "sec"], 59)
+  expect_equal(impute_time_max("2022-02-15 03:04:05")[, "sec"], 5L)
+
+  # secfrac is imputed when sec is missing, imputing with maximum decimal
+  expect_equal(impute_time_max("2022-02-15 03:04")[, "secfrac"], 0.999)
+  expect_equal(impute_time_max("2022-02-15 03:04:05")[, "secfrac"], 0)
+
+  # secfrac is considered populated, even when not explicitly provided, and
+  # therefore is not imputed
+  expect_equal(impute_time_max("2022-02-15 03:04:05")[, "secfrac"], 0)
+  expect_equal(impute_time_max("2022-02-15 03:04:05.678")[, "secfrac"], 0.678)
+})
+
+test_that("impute_time_max considers month length and leap year month lengths", {
+  expect_equal(impute_time_max("2022-02")[, "day"], 28L)
+  expect_equal(impute_time_max("2024-02")[, "day"], 29L)
+  expect_equal(impute_time_max("2024-01")[, "day"], 31L)
+  expect_equal(impute_time_max("2024-04")[, "day"], 30L)
+})
+
+test_that("impute_* with resolution only imputes desired fields", {
+  expect_equal(impute_time_min("2022", res = "day")[, "month"], 1)
+  expect_equal(impute_time_min("2022", res = "day")[, "day"], 1)
+  expect_equal(impute_time_min("2022", res = "day")[, "hour"], NA_real_)
+
+  expect_equal(impute_time_min("2022", res = "min")[, "hour"], 0)
+  expect_equal(impute_time_min("2022", res = "min")[, "min"], 0)
+  expect_equal(impute_time_min("2022", res = "min")[, "sec"], NA_real_)
+
+  expect_equal(impute_time_max("2022", res = "day")[, "month"], 12)
+  expect_equal(impute_time_max("2022", res = "day")[, "day"], 31)
+  expect_equal(impute_time_max("2022", res = "day")[, "hour"], NA_real_)
+
+  expect_equal(impute_time_max("2022", res = "min")[, "hour"], 23)
+  expect_equal(impute_time_max("2022", res = "min")[, "min"], 59)
+  expect_equal(impute_time_max("2022", res = "min")[, "sec"], NA_real_)
+})


### PR DESCRIPTION
Fixes

- Unnecessary warnings thrown when dates can't be parsed by `strptime`, despite not needing to leverage `strptime`-style weekday/yearday handlers (which used to get thrown any time an `impute_*_max` function was used)

Adds

- Plenty of tests for `impute_time_min` and `impute_time_max`