### PR TITLE
Fixing character coercion and adding tests; fixes README bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ vignettes/*.pdf
 # Shiny token, see https://shiny.rstudio.com/articles/shinyapps.html
 rsconnect/
 docs
+
+# ignore README preview
+README.html

--- a/R/class_partial_time_coercion.R
+++ b/R/class_partial_time_coercion.R
@@ -178,41 +178,45 @@ vec_cast.logical.partial_time <- function(x, to, ...) {
 
 coerce_parital_time_to_POSIXlt <- function(x, tz = "GMT", ...,  warn = TRUE) {
   if (warn) warn_partial(x)
-
   strptime(
     sprintf(
       "%04.f-%02.f-%02.fT%02.f:%02.f:%02.f.%s+%02.f%02.f",
-      attr(x, "fields")[, "year"]    %|NA|% 0,
-      attr(x, "fields")[, "month"]   %|NA|% 0,
-      attr(x, "fields")[, "day"]     %|NA|% 0,
-      attr(x, "fields")[, "hour"]    %|NA|% 0,
-      attr(x, "fields")[, "min"]     %|NA|% 0,
-      attr(x, "fields")[, "sec"]     %|NA|% 0,
-      substring(sprintf("%.03f", attr(x, "fields")[, "secfrac"] %|NA|% 0), 3),
-      attr(x, "fields")[, "tzhour"]  %|NA|% 0,
-      abs(attr(x, "fields")[, "tzmin"] %|NA|% 0)
+      x[, "year"]  %|NA|% 0,
+      x[, "month"] %|NA|% 0,
+      x[, "day"]   %|NA|% 0,
+      x[, "hour"]  %|NA|% 0,
+      x[, "min"]   %|NA|% 0,
+      x[, "sec"]   %|NA|% 0,
+      substring(sprintf("%.03f", x[, "secfrac"] %|NA|% 0), 3),
+      x[, "tzhour"] %|NA|% 0,
+      abs(x[, "tzmin"] %|NA|% 0)
     ),
     format = "%Y-%m-%dT%H:%M:%OS%z",
     tz = tz,  # sets origin for tz offset - assumes "GMT" as per iso8601
-    ...)
+    ...
+  )
 }
 
 
 
 #' @export
 as.character.partial_time <- function(x, ...) {
-  xf <- attr(x, "fields")
-  paste0(
-    ifelse(is.na(xf[, "year"]),     "", sprintf("%04d",  xf[, "year"])),
-    ifelse(is.na(xf[, "month"]),    "", sprintf("-%02d", xf[, "month"])),
-    ifelse(is.na(xf[, "day"]),      "", sprintf("-%02d", xf[, "day"])),
-    ifelse(is.na(xf[, "hour"]),     "", sprintf(" %02d", xf[, "hour"])),
-    ifelse(is.na(xf[, "min"]),      "", sprintf(":%02d", xf[, "min"])),
-    ifelse(is.na(xf[, "sec"]),      "", sprintf(":%02d", xf[, "sec"])),
-    ifelse(is.na(xf[, "secfrac"]),  "", substring(sprintf("%.03f", xf[, "secfrac"]), 3)),
-    ifelse(is.na(xf[, "tzhour"]),   "", sprintf(" %02d", xf[, "tzhour"])),
-    ifelse(is.na(xf[, "tzmin"]),    "", sprintf("%02d", abs(xf[, "tzmin"])))
+  nna <- !is.na(x)
+  out <- rep_len(NA_character_, length(x))
+
+  out[nna] <- paste0(
+    ifelse(is.na(x[nna, "year"]),    "", sprintf("%04d",  x[nna, "year"])),
+    ifelse(is.na(x[nna, "month"]),   "", sprintf("-%02d", x[nna, "month"])),
+    ifelse(is.na(x[nna, "day"]),     "", sprintf("-%02d", x[nna, "day"])),
+    ifelse(is.na(x[nna, "hour"]),    "", sprintf(" %02d", x[nna, "hour"])),
+    ifelse(is.na(x[nna, "min"]),     "", sprintf(":%02d", x[nna, "min"])),
+    ifelse(is.na(x[nna, "sec"]),     "", sprintf(":%02d", x[nna, "sec"])),
+    ifelse(is.na(x[nna, "secfrac"]), "", substring(sprintf("%.03f", x[nna, "secfrac"]), 2)),
+    ifelse(is.na(x[nna, "tzhour"]),  "", sprintf(" %02d", x[nna, "tzhour"])),
+    ifelse(is.na(x[nna, "tzmin"]),   "", sprintf("%02d", abs(x[nna, "tzmin"])))
   )
+
+  out
 }
 
 

--- a/R/propegate_na.R
+++ b/R/propegate_na.R
@@ -28,13 +28,14 @@ propagate_na_matrix <- function(x, keep_tz = FALSE) {
   cols <- grepl("^tz", colnames(x))
 
   # if not keeping tz fixed, propagate tz uncertainty back up through values
-  x_pos_na <- apply(x, 1, Position, f = is.na)
+  x_pos_na <- apply(x, 1, Position, f = is.na, nomatch = ncol(x) + 1L)
+
   subset_of_na <- col(x) >= x_pos_na
   if (keep_tz) {
     subset_of_na[, cols] <- FALSE
   } else {
     tz_na <- apply(is.na(x[, cols, drop = FALSE]), 1, any)
-    subset_of_na[tz_na, ] <- col(x[tz_na, , drop = FALSE]) + 1 >= x_pos_na
+    subset_of_na[tz_na, ] <- (col(x[tz_na, , drop = FALSE]) + 1) >= x_pos_na[tz_na]
   }
 
   # only propagate to tz fields if tz

--- a/README.Rmd
+++ b/README.Rmd
@@ -3,9 +3,8 @@ output: github_document
 ---
 
 ```{r, include = FALSE}
+options(crayon.enabled = FALSE, width = 80)
 library(parttime)
-
-knitr::knit_hooks$set(output = function(x, options) crayon::strip_style(x))
 ```
 
 # parttime
@@ -217,7 +216,7 @@ as.timespan(parttime(2019))
 `tibble`-style formatting makes it easy to see which components of each
 `partial_time` are missing.
 
-```{r, results = "hide"}
+```{r}
 library(dplyr)
 
 tibble(dates = iso8601_dates) %>%
@@ -226,8 +225,6 @@ tibble(dates = iso8601_dates) %>%
     imputed_times = impute_time_min(parttimes)
   )
 ```
-
-<img src="https://user-images.githubusercontent.com/18220321/64467475-b086ad00-d0cd-11e9-8e39-9a6e7e84a44e.png" width="75%"></img>
 
 # Roadmap
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,6 +2,12 @@
 output: github_document
 ---
 
+```{r, include = FALSE}
+library(parttime)
+
+knitr::knit_hooks$set(output = function(x, options) crayon::strip_style(x))
+```
+
 # parttime
 
 <!-- badges: start -->
@@ -202,10 +208,8 @@ definitely(parttime(2019) == parttime(2019), by = "year")
 
 Cast a partial time's missingness to a range of possible values
 
-```r
+```{r}
 as.timespan(parttime(2019))
-## <timespan[1]>
-## [1] [2019 — 2020) 
 ```
 
 ## Tidyverse Compatible `vctrs`
@@ -214,10 +218,12 @@ as.timespan(parttime(2019))
 `partial_time` are missing.
 
 ```{r, results = "hide"}
+library(dplyr)
+
 tibble(dates = iso8601_dates) %>%
   mutate(
-    parttimes = as.parttime(dates), 
-    imputed_times = as.POSIXct(impute_time(parttimes))
+    parttimes = as.parttime(dates),
+    imputed_times = impute_time_min(parttimes)
   )
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ list(pttms <- as.parttime(c("2022", "2022-02")))
 ```
 
     ## [[1]]
-    ## <partial_time<Y[38;5;246mM[39m[31mD[39m[31mh[39m[31mm[39m[31ms[39mZ>[2]> 
-    ## [1] "2022"    "2022[38;5;246m-[39m[38;5;246m0[39m2"
+    ## <partial_time<YMDhms+tz>[2]> 
+    ## [1] "2022"    "2022-02"
 
 We can access the components of each datetime as though the
 `partial_time` is a matrix of datetime fields, or using
@@ -55,7 +55,7 @@ pttms[, "year"]
 pttms[[1, "year"]]
 ## [1] 2022
 
-year(pttms)
+year(pttms)  # the first row are names of elements in a named numeric vector
 ##    2022 2022-02 
 ##    2022    2022
 
@@ -64,17 +64,17 @@ year(pttms[1])
 
 month(pttms[2]) <- 3
 pttms
-## <partial_time<Y[38;5;246mM[39m[31mD[39m[31mh[39m[31mm[39m[31ms[39mZ>[2]> 
-## [1] "2022"    "2022[38;5;246m-[39m[38;5;246m0[39m3"
+## <partial_time<YMDhms+tz>[2]> 
+## [1] "2022"    "2022-03"
 
 month(pttms[1]) <- 3
 pttms
-## <partial_time<YM[31mD[39m[31mh[39m[31mm[39m[31ms[39mZ>[2]> 
-## [1] "2022[38;5;246m-[39m[38;5;246m0[39m3" "2022[38;5;246m-[39m[38;5;246m0[39m3"
+## <partial_time<YMDhms+tz>[2]> 
+## [1] "2022-03" "2022-03"
 
 month(pttms) <- NA
 pttms
-## <partial_time<Y[31mM[39m[31mD[39m[31mh[39m[31mm[39m[31ms[39mZ>[2]> 
+## <partial_time<YMDhms+tz>[2]> 
 ## [1] "2022" "2022"
 ```
 
@@ -88,8 +88,8 @@ list(pttms <- as.parttime(c("2022", "2022-02")))
 ```
 
     ## [[1]]
-    ## <partial_time<Y[38;5;246mM[39m[31mD[39m[31mh[39m[31mm[39m[31ms[39mZ>[2]> 
-    ## [1] "2022"    "2022[38;5;246m-[39m[38;5;246m0[39m2"
+    ## <partial_time<YMDhms+tz>[2]> 
+    ## [1] "2022"    "2022-02"
 
 ``` r
 pttms[1] > pttms[2]
@@ -120,13 +120,12 @@ performed.
 
 ``` r
 impute_date_max(pttms[2])  # resolve date fields with maximum value
-## Warning in strptime(apply(match_m[i, c("year", "week", "weekday"), drop = FALSE], : (0-based) yday 367 in year 9999 is invalid
-## <partial_time<YMD[31mh[39m[31mm[39m[31ms[39m[31m+tz[39m>[1]> 
-## [1] "2022[38;5;246m-[39m[38;5;246m0[39m2[38;5;246m-[39m28"
+## <partial_time<YMDhms+tz>[1]> 
+## [1] "2022-02-28"
 
 impute_time(pttms[1], "1999-06-05T04:03:02")  # arbitrary imputation
 ## <partial_time<YMDhmsZ>[1]> 
-## [1] "2022[38;5;246m-[39m[38;5;246m0[39m6[38;5;246m-[39m[38;5;246m0[39m5 [38;5;246m0[39m4[38;5;246m:[39m03[38;5;246m:[39m02[38;5;246m.[39m000"
+## [1] "2022-06-05 04:03:02.000"
 ```
 
 ## The `partial_time` class
@@ -174,20 +173,24 @@ iso8601_dates <- c(
 as.parttime(iso8601_dates)
 ```
 
-    ## <partial_time<[38;5;246mY[39m[38;5;246mM[39m[38;5;246mD[39m[38;5;246mh[39m[38;5;246mm[39m[38;5;246ms[39m[38;5;246m+tz[39m>[15]> 
-    ##  [1] [31mNA[39m                             "2001"                         "2002[38;5;246m-[39m[38;5;246m0[39m1[38;5;246m-[39m[38;5;246m0[39m1"                  
-    ##  [4] "2004[38;5;246m-[39m[38;5;246m0[39m9[38;5;246m-[39m[38;5;246m0[39m1"                   "2005"                         "2006[38;5;246m-[39m[38;5;246m0[39m1[38;5;246m-[39m13"                  
-    ##  [7] "2007[38;5;246m-[39m10[38;5;246m-[39m[38;5;246m0[39m1 [38;5;246m0[39m8"                "2008[38;5;246m-[39m[38;5;246m0[39m9[38;5;246m-[39m20 [38;5;246m0[39m8[38;5;246m:[39m35"             "2009[38;5;246m-[39m[38;5;246m0[39m8[38;5;246m-[39m12 [38;5;246m0[39m8[38;5;246m:[39m35[38;5;246m:[39m02[38;5;246m.[39m880"     
-    ## [10] "2010[38;5;246m-[39m[38;5;246m0[39m7[38;5;246m-[39m22 [38;5;246m0[39m8[38;5;246m:[39m35[38;5;246m:[39m32[38;5;246m.[39m000"      "2011[38;5;246m-[39m[38;5;246m0[39m6[38;5;246m-[39m13 [38;5;246m0[39m8[38;5;246m:[39m35[38;5;246m:[39m32[38;5;246m.[39m123"      "2012[38;5;246m-[39m[38;5;246m0[39m5[38;5;246m-[39m23 [38;5;246m0[39m8[38;5;246m:[39m35[38;5;246m:[39m32[38;5;246m.[39m123"     
-    ## [13] "2013[38;5;246m-[39m[38;5;246m0[39m4[38;5;246m-[39m14 [38;5;246m0[39m8[38;5;246m:[39m35[38;5;246m:[39m32[38;5;246m.[39m123+0500" "2014[38;5;246m-[39m[38;5;246m0[39m3[38;5;246m-[39m24 [38;5;246m0[39m8[38;5;246m:[39m35[38;5;246m:[39m32[38;5;246m.[39m123+0530" "2015[38;5;246m-[39m[38;5;246m0[39m1[38;5;246m-[39m[38;5;246m0[39m1 [38;5;246m0[39m8[38;5;246m:[39m35[38;5;246m:[39m32[38;5;246m.[39m123+0530"
+    ## <partial_time<YMDhms+tz>[15]> 
+    ##  [1] NA                             "2001"                        
+    ##  [3] "2002-01-01"                   "2004-09-01"                  
+    ##  [5] "2005"                         "2006-01-13"                  
+    ##  [7] "2007-10-01 08"                "2008-09-20 08:35"            
+    ##  [9] "2009-08-12 08:35:02.880"      "2010-07-22 08:35:32.000"     
+    ## [11] "2011-06-13 08:35:32.123"      "2012-05-23 08:35:32.123+0000"
+    ## [13] "2013-04-14 08:35:32.123+0500" "2014-03-24 08:35:32.123+0530"
+    ## [15] "2015-01-01 08:35:32.123+0530"
 
 ## Imputing Timestamps
 
 ``` r
->  impute_time("2019", "2000-01-02T03:04:05.006+0730")
-## <partial_time<YMDhms+tz>[1]>
-## [1] "2019-01-02 03:04:05.006"
+impute_time("2019", "2000-01-02T03:04:05.006+0730")
 ```
+
+    ## <partial_time<YMDhms+0730>[1]> 
+    ## [1] "2019-01-02 03:04:05.006"
 
 ## Partial Datetime Comparisons
 
@@ -239,64 +242,92 @@ definitely(parttime(2019) == parttime(2019), by = "year")
 
     ## [1] TRUE
 
-## TRUE # but we know they’re equal within the same year
+``` r
+options(parttime.assume_tz_offset = NA)
+definitely(parttime(2019) == parttime(2019), by = "year")
+```
 
-options(parttime.assume_tz_offset = NA) definitely(parttime(2019) ==
-parttime(2019), by = “year”) ## NA # with an unknown timezone, these may
-not even be within the same year
+    ## [1] FALSE
 
+## Timespans
 
-    ## Timespans
+Cast a partial time’s missingness to a range of possible values
 
-    Cast a partial time's missingness to a range of possible values
+``` r
+as.timespan(parttime(2019))
+```
 
-    ```r
-    as.timespan(parttime(2019))
     ## <timespan[1]>
-    ## [1] [2019 — 2020) 
+    ## [1] [2019 — 2020)
 
 ## Tidyverse Compatible `vctrs`
 
+`tibble`-style formatting makes it easy to see which components of each
+`partial_time` are missing.
+
 ``` r
+library(dplyr)
+
 tibble(dates = iso8601_dates) %>%
   mutate(
-    parttimes = as.parttime(dates), 
-    imputed_times = as.POSIXct(impute_time(parttimes)))
+    parttimes = as.parttime(dates),
+    imputed_times = impute_time_min(parttimes)
+  )
 ```
 
-<img src="https://user-images.githubusercontent.com/18220321/64467475-b086ad00-d0cd-11e9-8e39-9a6e7e84a44e.png" width="75%"></img>
+    ## # A tibble: 15 × 3
+    ##    dates               parttimes                    imputed_times               
+    ##    <chr>               <pttm>                       <pttm>                      
+    ##  1 <NA>                NA                           NA                          
+    ##  2 2001                2001                         2001-01-01 00:00:00.000-1200
+    ##  3 2002-01-01          2002-01-01                   2002-01-01 00:00:00.000-1200
+    ##  4 2004-245            2004-09-01                   2004-09-01 00:00:00.000-1200
+    ##  5 2005-W13            2005                         2005-01-01 00:00:00.000-1200
+    ##  6 2006-W02-5          2006-01-13                   2006-01-13 00:00:00.000-1200
+    ##  7 2007-10-01T08       2007-10-01 08                2007-10-01 08:00:00.000-1200
+    ##  8 2008-09-20T08:35    2008-09-20 08:35             2008-09-20 08:35:00.000-1200
+    ##  9 2009-08-12T08:35.0… 2009-08-12 08:35:02.880      2009-08-12 08:35:02.880-1200
+    ## 10 2010-07-22T08:35:32 2010-07-22 08:35:32.000      2010-07-22 08:35:32.000-1200
+    ## 11 2011-06-13T08:35:3… 2011-06-13 08:35:32.123      2011-06-13 08:35:32.123-1200
+    ## 12 2012-05-23T08:35:3… 2012-05-23 08:35:32.123+0000 2012-05-23 08:35:32.123+0000
+    ## 13 2013-04-14T08:35:3… 2013-04-14 08:35:32.123+0500 2013-04-14 08:35:32.123+0500
+    ## 14 2014-03-24T08:35:3… 2014-03-24 08:35:32.123+0530 2014-03-24 08:35:32.123+0530
+    ## 15 20150101T08:35:32.… 2015-01-01 08:35:32.123+0530 2015-01-01 08:35:32.123+0530
 
 # Roadmap
 
-| class              | function/op                                   | description                | status |
-|--------------------|-----------------------------------------------|----------------------------|--------|
-| `partial_time`     | `parttime`                                    | create `partial_time`      | ✔︎\*︎  |
-| `partial_time`     | `as.parttime`                                 | cast to `partial_time`     | ✔︎\*︎  |
-| `partial_time`     | `>`,`<`,`<=`,`>=`                             | comparison operators       | ✔︎\*︎  |
-| `partial_time`     | `possibly`,`definitely`                       | uncertainty resolvers      | ✔︎\*︎  |
-| `partial_time`     | `==`,`!=`                                     | equivalence operators      | ✔︎\*︎  |
-| `partial_time`     | `min`,`max`,`pmin`,`pmax`                     | partial time extremes      | ✔︎\*︎  |
-| `partial_time`     | `impute_time`                                 | imputing partial time      | ✔︎\*︎  |
-| `partial_time`     | `to_gmt`                                      | convert to gmt timezone    | ✔︎\*︎  |
-| `partial_time`     | `print`                                       | printing                   | ✔︎\*︎  |
-| `partial_time`     | `format`                                      | format as character        | ✔︎\*︎  |
-| `partial_time`     | `<vctrs>`                                     | misc `vctrs` functions     | ✔︎\*︎  |
-| `partial_time`     | `<pillar>`                                    | misc `pillar` functions    | ✔︎\*︎  |
-| `partial_difftime` | `difftime`                                    | create `partial_difftime`  | ︎      |
-| `partial_difftime` | `as.difftime`                                 | cast to `partial_difftime` | ︎      |
-| `partial_difftime` | `>`,`<`,`<=`,`>=`                             | comparison operators       | ︎      |
-| `partial_difftime` | `possibly`,`definitely`                       | uncertainty resolvers      | ︎      |
-| `partial_difftime` | `==`,`!=`                                     | equivalence operators      | ︎      |
-| `partial_difftime` | `min`,`max`,`pmin`,`pmax`                     | partial difftime extremes  | ︎      |
-| `partial_difftime` | `print`                                       | printing                   |        |
-| `partial_difftime` | `format`                                      | format as character        |        |
-| `partial_difftime` | `<vctrs>`                                     | misc `vctrs` functions     |        |
-| `partial_difftime` | `<pillar>`                                    | misc `pillar` functions    |        |
-|                    | `` `-`(partial_time, partial_difftime) ``     | subraction                 | ︎      |
-|                    | `` `-`(partial_time, partial_time) ``         | subraction                 | ︎      |
-|                    | `` `-`(partial_difftime, partial_difftime) `` | subraction                 | ︎      |
-|                    | `` `-`(partial_difftime, partial_difftime) `` | addition                   | ︎      |
+## Summary
 
-\*[Debating internal representation of
-class](https://github.com/dgkf/parttime/issues/5), which would require
-tweaking existing implementations
+The `partial_time` class is pretty complete. The `timespan` and
+`partial_difftime` classes are still under construction!
+
+## In-development :construction:
+
+| status                  | class              | function/op                                   | description                |
+|-------------------------|--------------------|-----------------------------------------------|----------------------------|
+| :ballot_box_with_check: | `partial_time`     | `parttime`                                    | create `partial_time`      |
+| :ballot_box_with_check: | `partial_time`     | `as.parttime`                                 | cast to `partial_time`     |
+| :ballot_box_with_check: | `partial_time`     | `>`,`<`,`<=`,`>=`                             | comparison operators       |
+| :ballot_box_with_check: | `partial_time`     | `possibly`,`definitely`                       | uncertainty resolvers      |
+| :ballot_box_with_check: | `partial_time`     | `==`,`!=`                                     | equivalence operators      |
+| :ballot_box_with_check: | `partial_time`     | `min`,`max`,`pmin`,`pmax`                     | partial time extremes      |
+| :ballot_box_with_check: | `partial_time`     | `impute_time`                                 | imputing partial time      |
+| :ballot_box_with_check: | `partial_time`     | `to_gmt`                                      | convert to gmt timezone    |
+| :ballot_box_with_check: | `partial_time`     | `print`                                       | printing                   |
+| :ballot_box_with_check: | `partial_time`     | `format`                                      | format as character        |
+| :ballot_box_with_check: | `partial_time`     | `<vctrs>`                                     | misc `vctrs` functions     |
+| :ballot_box_with_check: | `partial_time`     | `<pillar>`                                    | misc `pillar` functions    |
+| :black_square_button:   | `partial_difftime` | `difftime`                                    | create `partial_difftime`  |
+| :black_square_button:   | `partial_difftime` | `as.difftime`                                 | cast to `partial_difftime` |
+| :black_square_button:   | `partial_difftime` | `>`,`<`,`<=`,`>=`                             | comparison operators       |
+| :black_square_button:   | `partial_difftime` | `possibly`,`definitely`                       | uncertainty resolvers      |
+| :black_square_button:   | `partial_difftime` | `==`,`!=`                                     | equivalence operators      |
+| :black_square_button:   | `partial_difftime` | `min`,`max`,`pmin`,`pmax`                     | partial difftime extremes  |
+| :black_square_button:   | `partial_difftime` | `print`                                       | printing                   |
+| :black_square_button:   | `partial_difftime` | `format`                                      | format as character        |
+| :black_square_button:   | `partial_difftime` | `<vctrs>`                                     | misc `vctrs` functions     |
+| :black_square_button:   | `partial_difftime` | `<pillar>`                                    | misc `pillar` functions    |
+| :black_square_button:   |                    | `` `-`(partial_time, partial_difftime) ``     | subraction                 |
+| :black_square_button:   |                    | `` `-`(partial_time, partial_time) ``         | subraction                 |
+| :black_square_button:   |                    | `` `-`(partial_difftime, partial_difftime) `` | subraction                 |
+| :black_square_button:   |                    | `` `-`(partial_difftime, partial_difftime) `` | addition                   |

--- a/tests/testthat/test_partial_time_as.R
+++ b/tests/testthat/test_partial_time_as.R
@@ -1,0 +1,59 @@
+test_that("as.character can convert partial_time to represenative string format", {
+  expect_silent({
+    pttms <- as.parttime(iso8601_dates)
+    pttms_chars <- as.character(pttms)
+  })
+
+  for (i in seq_along(iso8601_dates)) {
+    if (is.na(iso8601_dates[[i]])) {
+      expect_equal(pttms_chars[[i]], NA_character_)
+      next
+    }
+
+    expect_true(startsWith(pttms_chars[[i]], substring(iso8601_dates[[i]], 1, 4)))
+
+    if (!is.na(pttms[[i, "month"]]))
+      expect_match(pttms_chars[[i]], sprintf("\\b-%02.f\\b", pttms[[i, "month"]]))
+
+    if (!is.na(pttms[[i, "day"]]))
+      expect_match(pttms_chars[[i]], sprintf("\\b-%02.f\\b", pttms[[i, "day"]]))
+
+    if (!is.na(pttms[[i, "hour"]]))
+      expect_match(pttms_chars[[i]], sprintf("\\b %02.f\\b", pttms[[i, "hour"]]))
+
+    if (!is.na(pttms[[i, "min"]]))
+      expect_match(pttms_chars[[i]], sprintf("\\b:%02.f\\b", pttms[[i, "min"]]))
+
+    if (!is.na(pttms[[i, "sec"]]))
+      expect_match(pttms_chars[[i]], sprintf("\\b:%02.f\\b", pttms[[i, "sec"]]))
+
+    if (!is.na(pttms[[i, "secfrac"]]) && pttms[[i, "secfrac"]] != 0)
+      expect_match(pttms_chars[[i]], substring(sprintf("%.03f\\b", pttms[[i, "secfrac"]]), 2L))
+  }
+})
+
+test_that("as.POSIXct can convert partial_time to representative posix time", {
+  expect_silent({
+    pttms <- as.parttime(iso8601_dates)
+    pttms_ct <- as.POSIXct(pttms)
+  })
+
+  # expect that any date defined down to the day provides a valid POSIXct value
+  expect_true(all(is.na(pttms_ct[is.na(pttms[, "day"])])))
+
+  # expect that any date without day produces NA POSIXct value
+  expect_true(all(!is.na(pttms_ct[!is.na(pttms[, "day"])])))
+})
+
+test_that("as.POSIXct can convert partial_time to representative posix time", {
+  expect_silent({
+    pttms <- as.parttime(iso8601_dates)
+    pttms_ct <- as.POSIXlt(pttms)
+  })
+
+  # expect that any date defined down to the day provides a valid POSIXlt value
+  expect_true(all(is.na(pttms_ct[is.na(pttms[, "day"])])))
+
+  # expect that any date without day produces NA POSIXlt value
+  expect_true(all(!is.na(pttms_ct[!is.na(pttms[, "day"])])))
+})


### PR DESCRIPTION
A holdover from when the package used the old-style `vctrs` `rcrd` structure which didn't support matrix fields. Most of the code was migrated over, but I must have missed this bit. Now the character coercion should work just fine and the example in the README will work.

- Updates character coercion so that it works with modern `vctrs`
- Fixed a bug in imputation with mixed timezones
- Updated README