### PR TITLE
A set of valid and invalid values for CDISC standards

### DIFF
--- a/tests/testthat/setup_test_data.R
+++ b/tests/testthat/setup_test_data.R
@@ -15,3 +15,69 @@ iso8601_dates <- c(
   "2013-02-15T16:17:18.019+07:30",  # time offset with min from GMT
   "20140316T17:18:19.020+08:00"  # condensed form
 )
+
+# From the SDTMIG version 3.4
+# (https://www.cdisc.org/system/files/members/standard/foundational/SDTMIG_v3.4.pdf)
+
+# From the SDTMIG version 3.4, Page 39: decreasing precision, fully specified
+cdisc_datetimes_decreasing_sensitivity <- c(
+  "2003-12-15T13:14:17.123",
+  "2003-12-15T13:14:17",
+  "2003-12-15T13:14",
+  "2003-12-15T13",
+  "2003-12-15",
+  "2003-12",
+  "2003"
+)
+
+# From the SDTMIG version 3.4, Page 40: intervals of uncertainty
+cdisc_intervals <- c(
+  "2003-12-15T10:00/2003-12-15T10:30", # Between 10:00 and 10:30 on the morning of December 15, 2003
+  "2003-01-01/2003-02-15", # Between the first of this year (2003) until "now" (February 15, 2003)
+  "2003-12-01/2003-12-10", # Between the first and the tenth of December, 2003
+  "2003-01-01/2003-06-30" # Sometime in the first half of 2003
+)
+
+# From the SDTMIG version 3.4, Page 40: missing middle parts
+cdisc_missing_in_middle <- c(
+  "2003-12-15T13:15:17", # December 15, 2003 13:15:17; Date/time to the nearest secon
+  "2003-12-15T-:15", # December 15, 2003 ??:15 Unknown hour with known minutes
+  "2003-12-15T13:-:17", # December 15, 2003 13:??:17 Unknown minutes with known date, hours, and seconds
+  "2003---15", # The 15th of some month in 2003, time not collected Unknown month and time with known year and day
+  "--12-15", # December 15, but can't remember the year, time not collected; Unknown year with known month and day
+  "-----T07:15" # 7:15 of some unknown date Unknown date with known hour and minute
+)
+
+# A general list of invalid datetimes
+invalid_datetime_general <- c(
+  "20221", # 5 digit years are invalid
+  "2022-1", # 1 digit months are invalid
+  "2022-001", # 3 digit months are invalid
+  "2022:01", # date separator must be a dash
+
+  "2022-01-1", # 1 digit days are invalid
+  "2022-01-001", # 3 digit days are invalid
+  "2022-01-01t01", # T must be upper case
+  "2022-01-01T1", # 1 digit hours are invalid
+  "2022-01-01T001", # 3 digit hours are invalid
+  "2022-01-01T001", # 3 digit hours are invalid
+  "2022-01-01T01-01", # time separator must be colon
+  "2022-01-01T01:1", # 1 digit minutes are invalid
+  "2022-01-01T01:001", # 3 digit minutes are invalid
+  "2022-01-01T01:01:1", # 1 digit seconds are invalid
+  "2022-01-01T01:01:001", # 3 digit seconds are invalid
+  
+  "foo", # general text that is not date-like
+  "" # an empty string is not a valid dose
+)
+
+# Date-times that are invalid with CDISC but are valid with ISO 8601
+invalid_datetime_cdisc <- c(
+  # From the middle of page 39 in the SDTMIG version 3.4:
+  # Extended format ISO 8601 (with dashes and colons) is required
+  "202201", # year and month in non-extended format
+  "20220101T010101", # year, month, day, hour, minute, second in non-extended format
+  # From the top of page 39 in the SDTMIG version 3.4:
+  # comma separator for fractions is not allowed by CDISC
+  "2022-01-01T01:01:01,0"
+)

--- a/tests/testthat/setup_test_data.R
+++ b/tests/testthat/setup_test_data.R
@@ -40,7 +40,7 @@ cdisc_intervals <- c(
 
 # From the SDTMIG version 3.4, Page 40: missing middle parts
 cdisc_missing_in_middle <- c(
-  "2003-12-15T13:15:17", # December 15, 2003 13:15:17; Date/time to the nearest secon
+  "2003-12-15T13:15:17", # December 15, 2003 13:15:17; Date/time to the nearest second
   "2003-12-15T-:15", # December 15, 2003 ??:15 Unknown hour with known minutes
   "2003-12-15T13:-:17", # December 15, 2003 13:??:17 Unknown minutes with known date, hours, and seconds
   "2003---15", # The 15th of some month in 2003, time not collected Unknown month and time with known year and day


### PR DESCRIPTION
This PR adds valid and invalid examples of date-times for handling CDISC standards.  Various tests may be constructed around these.