### PR TITLE
Removing secfrac and tzmin components

### DIFF
--- a/R/class_partial_time.R
+++ b/R/class_partial_time.R
@@ -20,20 +20,14 @@ methods::setClass("partial_time")
 #' @export
 parttime <- function(
   year = NA, month = NA, day = NA, hour = NA, min = NA, sec = NA,
-  tzhour = interpret_tz(getOption("parttime.assume_tz_offset", NA)) %/% 60,
-  tzmin  = interpret_tz(getOption("parttime.assume_tz_offset", NA)) %% 60
+  tzhour = interpret_tz(getOption("parttime.assume_tz_offset", NA)) / 60
 ) {
   # handle special case when no arguments are provided
   args <- as.list(sys.call()[-1])
   if (!length(args)) return(parttime(NA)[0])
 
-  secfrac <- sec %% 1
-  sec <- sec %/% 1
-
-  fields <- vctrs::vec_recycle_common(year, month, day, hour, min, sec,
-      secfrac, tzhour, tzmin)
-
-  names(fields) <- append(names(formals()), "secfrac", 6)
+  fields <- vctrs::vec_recycle_common(year, month, day, hour, min, sec, tzhour)
+  names(fields) <- names(formals())
 
   l <- length(fields[[1]])
   as.parttime(matrix(

--- a/R/class_partial_time.R
+++ b/R/class_partial_time.R
@@ -12,7 +12,6 @@ methods::setClass("partial_time")
 #' @param min numeric vector to use for partial time min component
 #' @param sec numeric vector to use for partial time sec component
 #' @param tzhour numeric vector to use for partial time tzhour component
-#' @param tzmin numeric vector to use for partial time tzmin component
 #'
 #' @examples
 #' parttime(2019)

--- a/R/class_partial_time_compat_lubridate.R
+++ b/R/class_partial_time_compat_lubridate.R
@@ -238,18 +238,12 @@ methods::setMethod(
 #' @rdname parttime_access_and_assign
 #' @rawNamespace S3method(lubridate::second,partial_time)
 #' @export
-second.partial_time <- function(x) {
-  get_field(x, "sec") + get_field(x, "secfrac")
-}
+second.partial_time <- gen_get_field_fn("sec")
 
 #' @rdname parttime_access_and_assign
 #' @usage \method{second}{partial_time}(x) <- value
 #' @export
-`second<-.partial_time` <- function(x, value) {
-  sec <- trunc(value)
-  secfrac <- value - sec
-  set_field(x, c("sec", "secfrac"), cbind(sec = sec, secfrac = secfrac))
-}
+`second<-.partial_time` <- gen_set_field_fn("sec")
 
 #' @rdname parttime_access_and_assign
 #' @importMethodsFrom lubridate second<-
@@ -268,14 +262,14 @@ methods::setMethod(
 #' @rawNamespace S3method(lubridate::tz,partial_time)
 #' @export
 tz.partial_time <- function(x) {
-  get_field(x, "tzhour") * 60 + get_field(x, "tzmin")
+  get_field(x, "tzhour") * 60
 }
 
 #' @rdname parttime_access_and_assign
 #' @usage \method{tz}{partial_time}(x) <- value
 #' @export
 `tz<-.partial_time` <- function(x, value) {
-  set_field(x, c("tzhour", "tzmin"), cbind(tzhour = value %/% 60, tzmin = value %% 60))
+  set_field(x, "tzhour", value / 60)
 }
 
 
@@ -302,8 +296,7 @@ methods::setMethod(
     vctrs::field(e1, "pttm_mat")[, "day"]     <- day(e1)    + attr(e2, "day")
     vctrs::field(e1, "pttm_mat")[, "hour"]    <- hour(e1)   + attr(e2, "hour")
     vctrs::field(e1, "pttm_mat")[, "min"]     <- minute(e1) + attr(e2, "minute")
-    vctrs::field(e1, "pttm_mat")[, "sec"]     <- second(e1) + e2_secs
-    vctrs::field(e1, "pttm_mat")[, "secfrac"] <- get_field(e1, "secfrac") + (e2 - e2_secs)
+    vctrs::field(e1, "pttm_mat")[, "sec"]     <- second(e1) + attr(e2, "second")
     vctrs::field(e1, "pttm_mat") <- reflow_fields(vctrs::field(e1, "pttm_mat"))
 
     e1

--- a/R/class_partial_time_compat_vctrs.R
+++ b/R/class_partial_time_compat_vctrs.R
@@ -16,9 +16,8 @@ obj_print_header.partial_time <- function(x, ...) {
   perc_complete <- apply(!is.na(vctrs::field(x, "pttm_mat")), 2, mean)
 
   # reduce a couple components down to single terms
-  perc_complete["sec"] <- min(perc_complete[c("sec", "secfrac")])
-  perc_complete["tzhour"] <- min(perc_complete[c("tzhour", "tzmin")])
-  perc_complete <- perc_complete[!names(perc_complete) %in% c("secfrac", "tzmin")]
+  perc_complete["sec"] <- perc_complete["sec"]
+  perc_complete["tzhour"] <- perc_complete["tzhour"]
   perc_complete <- perc_complete[datetime_parts]
 
   # get singular timezone if consistent across entire vector
@@ -84,9 +83,9 @@ obj_print_footer.partial_time <- function(x, ...) {
 
 
 tz_consensus <- function(xmat) {
-  if (nrow(xmat) < 1 || !all(c("tzhour", "tzmin") %in% colnames(xmat)))
+  if (nrow(xmat) < 1 || "tzhour" %in% colnames(xmat))
     return(FALSE)
 
-  tzs <- xmat[, c("tzhour", "tzmin"), drop = FALSE] %*% c(100,  1)
+  tzs <- xmat[, "tzhour"]
   if (isTRUE(all(tzs == tzs[1]))) tzs[[1]] else FALSE
 }

--- a/R/class_partial_time_utils.R
+++ b/R/class_partial_time_utils.R
@@ -7,7 +7,7 @@ minimally_increment.partial_time <- function(x) {
   x_mat <- vctrs::field(x, "pttm_mat")
 
   # increment last available time field
-  col_tz <- colnames(x_mat) %in% c("tzhour", "tzmin")
+  col_tz <- colnames(x_mat) == "tzhour"
   last_indx <- which(col(x_mat) == apply(x_mat, 1, Position, f = is.na) - 1)
   x_mat[, !col_tz][last_indx] <- x_mat[, !col_tz][last_indx] + 1
 
@@ -19,7 +19,7 @@ minimally_increment.partial_time <- function(x) {
 minimally_increment.matrix <- function(x_mat) {
   # increment last available time field
   col_inc <- colnames(x_mat) %in% "inclusive"
-  col_tz <- colnames(x_mat) %in% c("tzhour", "tzmin")
+  col_tz <- colnames(x_mat) == "tzhour"
   last_indx <- which(col(x_mat) == apply(x_mat, 1, Position, f = is.na) - 1)
   x_mat[, !col_tz & !col_inc][last_indx] <- x_mat[, !col_tz & !col_inc][last_indx] + 1
   x_mat[, !col_inc] <- reflow_fields(x_mat[, !col_inc, drop = FALSE])

--- a/R/class_timespan_coercion.R
+++ b/R/class_timespan_coercion.R
@@ -4,7 +4,7 @@
 #' @inheritParams as.parttime
 #'
 #' @export
-as.timespan <- function(x, ..., format = parse_iso8601_as_timespan) {
+as.timespan <- function(x, ..., format = parse_iso8601_datetime_as_timespan) {
   UseMethod("as.timespan")
 }
 

--- a/R/impute.R
+++ b/R/impute.R
@@ -5,7 +5,7 @@
 #' @param tz a character timezone name for imputation, a character value to use
 #'   as the timezone part of the datetime or an numeric minute offset.
 #' @param ... additional individual named fields to impute. Can be one of
-#'   "year", "month", "day", "hour", "min", "sec", "secfrac", "tzhour", "tzmin".
+#'   "year", "month", "day", "hour", "min", "sec", "tzhour"
 #'
 #' @return a new partial_time with specified fields imputed
 #'
@@ -130,8 +130,6 @@ impute_time.partial_time <- function(x, time, tz = "GMT", ..., res = NULL) {
   tzhour_na <- is.na(vctrs::field(impute_pttm, "pttm_mat")[, "tzhour"])
   vctrs::field(impute_pttm, "pttm_mat")[tzhour_na, "tzhour"] <- tz %/% 60
 
-  tzmin_na <- is.na(vctrs::field(impute_pttm, "pttm_mat")[, "tzmin"])
-  vctrs::field(impute_pttm, "pttm_mat")[tzmin_na, "tzmin"] <- tz %% 60
 
   # recycle imputed partial_time to length of x
   impute_pttm <- vctrs::vec_recycle(impute_pttm, length(x))
@@ -161,8 +159,7 @@ impute_time.matrix <- function(x, time, tz = "GMT", ...) {
   time <- as.matrix(time)
   time <- time[, datetime_parts, drop = FALSE]
 
-  time[is.na(time[, "tzhour"]), "tzhour"] <- tz %/% 60
-  time[is.na(time[, "tzmin"]), "tzmin"] <- tz %% 60
+  time[is.na(time[, "tzhour"]), "tzhour"] <- tz / 60
 
   xna <- is.na(x[,datetime_parts])
   x[, datetime_parts][xna] <- matrix(rep(time, nrow(x)), ncol = ncol(time), byrow = TRUE)[xna]
@@ -193,7 +190,10 @@ impute_partial_time_to_chr <- function(x, time, ...) {
 
   with(fields, sprintf(
     "%04.f-%02.f-%02.f %02.f:%02.f:%02.f.%03.f +%02.f%02.f",
-    year, month, day, hour, min, sec, secfrac * 1000, tzhour, tzmin))
+    year, month, day, hour, min,
+    sec %/% 1, sec %% 1 * 1000,
+    tzhour %/% 1, tzhour %/% 1 * 60
+  ))
 }
 
 

--- a/R/parse_cdisc.R
+++ b/R/parse_cdisc.R
@@ -24,8 +24,12 @@ re_cdisc_datetime <- paste0(
         ")",
       ")?",
       "(?:\\g{colon}",
-        "(?<sec>[0-5]\\d|-)",
-        "(?<secfrac>\\.\\d+)?",
+        "(?<sec>",
+          "[0-5]\\d",
+          "(?<secfrac>\\.\\d+)?",
+        "|",
+          "-",
+        ")",
       ")?",
     ")?",
   ")?$"
@@ -50,9 +54,6 @@ parse_cdisc_datetime <- function(x, warn = TRUE, ...) {
   m <- parse_to_parttime_matrix(x, regex = re_cdisc_datetime)
   m[m == "-"] <- ""
   m <- clean_parsed_parttime_matrix(m)
-
-  i <- !is.na(m[, "sec"]) & is.na(m[, "secfrac"])
-  m[i, "secfrac"] <- 0
 
   first_na <- apply(is.na(m), 1L, Position, f = identity)
   last_val <- apply(!is.na(m), 1L, Position, f = identity)

--- a/R/parse_to_parttime_matrix.R
+++ b/R/parse_to_parttime_matrix.R
@@ -47,12 +47,9 @@ clean_parsed_parttime_matrix <- function(m) {
 
   if (any(tzhour_na)) {
     gmt_offset <- interpret_tz(getOption("parttime.assume_tz_offset", NA))
-    m[!all_na & tzhour_na, "tzhour"] <- gmt_offset %/% 60
-    m[!all_na & tzhour_na, "tzmin"]  <- gmt_offset %%  60
+    m[!all_na & tzhour_na, "tzhour"] <- gmt_offset / 60
   }
 
-  # when tzhour is available
-  m[!tzhour_na & is.na(m[, "tzmin"]), "tzmin"] <- 0
   m[, datetime_parts, drop = FALSE]
 }
 

--- a/R/reflow_fields.R
+++ b/R/reflow_fields.R
@@ -35,13 +35,8 @@ reflow_fields <- function(fmat, days) {
   fmat[, "hour"] <- fmat[, "hour"] %/% 1
   fmat[, "sec"] <- fmat[, "sec"] + fmat[, "min"] %% 1 * 60
   fmat[, "min"] <- fmat[, "min"] %/% 1
-  fmat[, "secfrac"] <- fmat[, "secfrac"] + fmat[, "sec"] %% 1
-  fmat[, "sec"] <- fmat[, "sec"] %/% 1
 
   # flow overflow back up to parent fields
-  na <- is.na(fmat[, "secfrac"])
-  fmat[!na, "sec"] <- fmat[!na, "sec"] + fmat[!na, "secfrac"] %/% 1
-  fmat[, "secfrac"] <- fmat[, "secfrac"] %% 1
   na <- is.na(fmat[, "sec"])
   fmat[!na, "min"] <- fmat[!na, "min"] + fmat[!na, "sec"] %/% 60
   fmat[, "sec"] <- fmat[, "sec"] %% 60

--- a/R/to_gmt.R
+++ b/R/to_gmt.R
@@ -11,9 +11,9 @@ to_gmt <- function(x) {
 
 #' @export
 to_gmt.matrix <- function(x) {
-  x[, "hour"] <- x[, "hour"] + x[, "tzhour"]
-  x[, "min"]  <- x[, "min"]  + x[, "tzmin"]
-  x[, c("tzhour", "tzmin")] <- 0
+  x[, "hour"] <- x[, "hour"] + x[, "tzhour"] %/% 1
+  x[, "min"]  <- x[, "min"]  + x[, "tzhour"] %% 1 * 60
+  x[, "tzhour"] <- 0
   reflow_fields(x)
 }
 
@@ -44,6 +44,6 @@ to_gmt.timespan <- function(x) {
 
 prune_tz <- function(x) {
   args <- rep_len(alist(, ), length(dim(x)))
-  args[[2]] <- -which(dimnames(x)[[2]] %in% c("tzhour", "tzmin"))
+  args[[2]] <- -which(dimnames(x)[[2]] %in% "tzhour")
   do.call("[", append(list(x), args))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,9 +9,7 @@ datetime_parts <- c(
   "hour",
   "min",
   "sec",
-  "secfrac",
-  "tzhour",
-  "tzmin"
+  "tzhour"
 )
 
 

--- a/man/as.parttime.Rd
+++ b/man/as.parttime.Rd
@@ -37,7 +37,7 @@ as.parttime(c("1234", "5678"), format = "(?<year>\\\\d{4})")
 
 # format function that returns a matrix of components
 utf8_str <- function(x) intToUtf8(utf8ToInt(x) - 16)
-as.parttime(c("B@@", "B@A@"), format = function(x) cbind(year = sapply(x, utf8_str)))
+as.parttime(c("B@", "B@A@"), format = function(x) cbind(year = sapply(x, utf8_str)))
 # <partial_time<YMDhmsZ>[2]>
 # [1] "2000" "2010"
 

--- a/man/as.timespan.Rd
+++ b/man/as.timespan.Rd
@@ -4,7 +4,7 @@
 \alias{as.timespan}
 \title{Cast an object to a timespan}
 \usage{
-as.timespan(x, ..., format = parse_iso8601_as_timespan)
+as.timespan(x, ..., format = parse_iso8601_datetime_as_timespan)
 }
 \arguments{
 \item{x}{an object to cast}

--- a/man/impute_time.Rd
+++ b/man/impute_time.Rd
@@ -45,7 +45,7 @@ impute_date_mid(x, ..., res = "day")
 as the timezone part of the datetime or an numeric minute offset.}
 
 \item{...}{additional individual named fields to impute. Can be one of
-"year", "month", "day", "hour", "min", "sec", "secfrac", "tzhour", "tzmin".}
+"year", "month", "day", "hour", "min", "sec", "tzhour"}
 
 \item{res}{the highest resolution datetime field used for imputation. Either
 a character value represented the highest resolution field or \code{NULL}

--- a/man/parse_iso8601_matrix.Rd
+++ b/man/parse_iso8601_matrix.Rd
@@ -6,9 +6,6 @@
 \usage{
 parse_iso8601_matrix(dates)
 }
-\arguments{
-\item{dates}{character vector of dates to parse for iso8601 components}
-}
 \description{
 Parse an iso8601 datetime to a parttime-like matrix
 }

--- a/man/parse_parttime.Rd
+++ b/man/parse_parttime.Rd
@@ -51,9 +51,7 @@ each of the nine datetime fields:
 \item{\code{hour}}
 \item{\code{min}}
 \item{\code{sec}}
-\item{\code{secfrac}}
 \item{\code{tzhour}}
-\item{\code{tzmin}}
 }
 }
 \note{

--- a/man/parttime.Rd
+++ b/man/parttime.Rd
@@ -11,8 +11,7 @@ parttime(
   hour = NA,
   min = NA,
   sec = NA,
-  tzhour = interpret_tz(getOption("parttime.assume_tz_offset", NA))\%/\%60,
-  tzmin = interpret_tz(getOption("parttime.assume_tz_offset", NA))\%\%60
+  tzhour = interpret_tz(getOption("parttime.assume_tz_offset", NA))/60
 )
 }
 \arguments{

--- a/man/parttime.Rd
+++ b/man/parttime.Rd
@@ -28,8 +28,6 @@ parttime(
 \item{sec}{numeric vector to use for partial time sec component}
 
 \item{tzhour}{numeric vector to use for partial time tzhour component}
-
-\item{tzmin}{numeric vector to use for partial time tzmin component}
 }
 \description{
 Create a parttime object

--- a/man/vec_cast.partial_time.character.Rd
+++ b/man/vec_cast.partial_time.character.Rd
@@ -34,17 +34,17 @@ dates <- c(
   "2001",
   "2002-01-01",
   "2004-245", # yearday
-  "2005-W13",  # yearweek
-  "2006-W02-5",  # yearweek + weekday
+  "2005-W13", # yearweek
+  "2006-W02-5", # yearweek + weekday
   "2007-10-01T08",
   "2008-09-20T08:35",
-  "2009-08-12T08:35.048",  # fractional minute
+  "2009-08-12T08:35.048", # fractional minute
   "2010-07-22T08:35:32",
-  "2011-06-13T08:35:32.123",  # fractional second
-  "2012-05-23T08:35:32.123Z",  # Zulu time
-  "2013-04-14T08:35:32.123+05",  # time offset from GMT
-  "2014-03-24T08:35:32.123+05:30",  # time offset with min from GMT
-  "20150101T083532.123+0530"  # condensed form
+  "2011-06-13T08:35:32.123", # fractional second
+  "2012-05-23T08:35:32.123Z", # Zulu time
+  "2013-04-14T08:35:32.123+05", # time offset from GMT
+  "2014-03-24T08:35:32.123+05:30", # time offset with min from GMT
+  "20150101T083532.123+0530" # condensed form
 )
 
 as.parttime(dates)

--- a/tests/testthat/test_missing_middle_impute.R
+++ b/tests/testthat/test_missing_middle_impute.R
@@ -7,7 +7,8 @@ test_that("missing-in-the-middle imputes minimum and maximum values", {
   expect_equal(imp_mitm[, "day"], 5L)
   expect_equal(imp_mitm[, "hour"], 23L)
   expect_equal(imp_mitm[, "min"], 59L)
-  expect_equal(imp_mitm[, "sec"], 59)
+  expect_equal(imp_mitm[, "sec"] %/% 1, 59)
+  expect_equal(imp_mitm[, "sec"] %% 1, 0.999)
 
   imp_mitm <- impute_time_min(mitm)
   expect_equal(imp_mitm[, "month"], 1L)

--- a/tests/testthat/test_partial_time_as.R
+++ b/tests/testthat/test_partial_time_as.R
@@ -25,10 +25,7 @@ test_that("as.character can convert partial_time to represenative string format"
       expect_match(pttms_chars[[i]], sprintf("\\b:%02.f\\b", pttms[[i, "min"]]))
 
     if (!is.na(pttms[[i, "sec"]]))
-      expect_match(pttms_chars[[i]], sprintf("\\b:%02.f\\b", pttms[[i, "sec"]]))
-
-    if (!is.na(pttms[[i, "secfrac"]]) && pttms[[i, "secfrac"]] != 0)
-      expect_match(pttms_chars[[i]], substring(sprintf("%.03f\\b", pttms[[i, "secfrac"]]), 2L))
+      expect_match(pttms_chars[[i]], sprintf("\\b:%02.3f\\b", pttms[[i, "sec"]]))
   }
 })
 

--- a/tests/testthat/test_partial_time_assignment.R
+++ b/tests/testthat/test_partial_time_assignment.R
@@ -24,12 +24,12 @@ test_that("partial_time assignment helpers mutate field data", {
   expect_equal(unname(pttms[, "min"]), (1:15 * 4) %% 60)
 
   # second
-  expect_silent(second(pttms) <- (1:15 * 7) %% 60)
-  expect_equal(unname(pttms[, "sec"]), (1:15 * 7) %% 60)
+  expect_silent(second(pttms) <- (1:15 * 7.89) %% 60)
+  expect_equal(unname(pttms[, "sec"]), (1:15 * 7.89) %% 60)
 
   # tz
   expect_silent(tz(pttms) <- 1:15 * 20)
-  expect_equal(unname(pttms[, "tzhour"] * 60 + pttms[, "tzmin"]), 1:15 * 20)
+  expect_equal(unname(pttms[, "tzhour"]), (1:15 * 20) / 60)
 })
 
 test_that("partial_time assignment with out-of-range values reflows fields", {

--- a/tests/testthat/test_partial_time_comp_ops.R
+++ b/tests/testthat/test_partial_time_comp_ops.R
@@ -40,8 +40,8 @@ test_that("definitely() excludes uncertainty for overlapping windows", {
 test_that("timezone causes uncertainty in comparison", {
   expect_equal({
     as.logical(
-      parttime(2019, tzhour = NA, tzmin = NA) <
-      parttime(2019, tzhour = NA, tzmin = NA)
+      parttime(2019, tzhour = NA) <
+      parttime(2019, tzhour = NA)
     )
   }, {
     NA

--- a/tests/testthat/test_partial_time_format.R
+++ b/tests/testthat/test_partial_time_format.R
@@ -27,18 +27,15 @@ test_that("parttime formats to iso8601-style as character", {
       expect_match(fmt, sprintf("%02.f", pttm[, "min"]))
 
     if (!is.na(pttm[, "sec"]))
-      expect_match(fmt, sprintf("%02.f", pttm[, "sec"]))
-
-    if (!is.na(pttm[, "secfrac"]))
-      expect_match(fmt, sprintf("%03.f", pttm[, "secfrac"] * 1000))
+      expect_match(fmt, sprintf(if (pttm[,"sec"] %% 1 == 0) "%02.f" else "%02.3f", pttm[, "sec"]))
 
     if (is.na(pttm[, "tzhour"]))
-      expect_no_match(fmt, "[+-]\\d{4}$")
+      expect_no_match(fmt, "[+-]\\d{2}:\\d{2}$")
 
     if (!is.na(pttm[, "tzhour"]))
-      expect_match(fmt_tz, sprintf("%02.f%02.f", pttm[, "tzhour"], pttm[, "tzmin"]))
+      expect_match(fmt_tz, sprintf("%02.f:%02.f", pttm[, "tzhour"] %/% 1, pttm[, "tzhour"] %% 1 * 60))
 
     if (!is.na(pttm[, "tzhour"]))
-      expect_no_match(fmt_no_tz, sprintf("%02.f%02.f$", pttm[, "tzhour"], pttm[, "tzmin"]))
+      expect_no_match(fmt_no_tz, sprintf("%04.f$", pttm[, "tzhour"] * 60))
   })
 })

--- a/tests/testthat/test_partial_time_impute.R
+++ b/tests/testthat/test_partial_time_impute.R
@@ -17,9 +17,7 @@ test_that("impute_time_min populates fields with minimum appropriate data", {
 
   expect_equal(impute_time_min("2022-02-15 03:04")[, "sec"], 0L)
   expect_equal(impute_time_min("2022-02-15 03:04:05")[, "sec"], 5L)
-
-  expect_equal(impute_time_min("2022-02-15 03:04:05")[, "secfrac"], 0L)
-  expect_equal(impute_time_min("2022-02-15 03:04:05.678")[, "secfrac"], 0.678)
+  expect_equal(impute_time_min("2022-02-15 03:04:05.678")[, "sec"], 5.678)
 })
 
 test_that("impute_time_* operates on vectors of partial_time", {
@@ -47,17 +45,8 @@ test_that("impute_time_max populates fields with maximum appropriate data", {
   expect_equal(impute_time_max("2022-02-15 03")[, "min"], 59L)
   expect_equal(impute_time_max("2022-02-15 03:04")[, "min"], 4L)
 
-  expect_equal(impute_time_max("2022-02-15 03:04")[, "sec"], 59)
+  expect_equal(impute_time_max("2022-02-15 03:04")[, "sec"], 59.999)
   expect_equal(impute_time_max("2022-02-15 03:04:05")[, "sec"], 5L)
-
-  # secfrac is imputed when sec is missing, imputing with maximum decimal
-  expect_equal(impute_time_max("2022-02-15 03:04")[, "secfrac"], 0.999)
-  expect_equal(impute_time_max("2022-02-15 03:04:05")[, "secfrac"], 0)
-
-  # secfrac is considered populated, even when not explicitly provided, and
-  # therefore is not imputed
-  expect_equal(impute_time_max("2022-02-15 03:04:05")[, "secfrac"], 0)
-  expect_equal(impute_time_max("2022-02-15 03:04:05.678")[, "secfrac"], 0.678)
 })
 
 test_that("impute_time_max considers month length and leap year month lengths", {

--- a/tests/testthat/test_partial_time_parse_cdisc.R
+++ b/tests/testthat/test_partial_time_parse_cdisc.R
@@ -16,11 +16,9 @@ test_that("parsing cdisc dates works for example date strings", {
   expect_true(all(pttm_mat[1:3, "min"] == 14))
   expect_true(all(is.na(pttm_mat[4:7, "min"])))
 
-  expect_true(all(pttm_mat[1:2, "sec"] == 17))
+  expect_true(all(pttm_mat[1, "sec"] == 17.123))
+  expect_true(all(pttm_mat[2, "sec"] == 17))
   expect_true(all(is.na(pttm_mat[3:7, "sec"])))
-
-  expect_true(all(pttm_mat[1:2, "secfrac"] == c(0.123, 0)))
-  expect_true(all(is.na(pttm_mat[3:7, "secfrac"])))
 })
 
 test_that("parsing cdisc dates requires dash separator", {

--- a/tests/testthat/test_partial_time_parse_iso8601.R
+++ b/tests/testthat/test_partial_time_parse_iso8601.R
@@ -21,11 +21,9 @@ test_that("parsing typical cdisc works using iso8601 parser", {
   expect_true(all(pttm_mat[1:3, "min"] == 14))
   expect_true(all(is.na(pttm_mat[4:7, "min"])))
 
-  expect_true(all(pttm_mat[1:2, "sec"] == 17))
+  expect_true(all(pttm_mat[1, "sec"] == 17.123))
+  expect_true(all(pttm_mat[2, "sec"] == 17))
   expect_true(all(is.na(pttm_mat[3:7, "sec"])))
-
-  expect_true(all(pttm_mat[1:2, "secfrac"] == c(0.123, 0)))
-  expect_true(all(is.na(pttm_mat[3:7, "secfrac"])))
 })
 
 test_that("parsing invalid iso8601 with mixed formats throws warning and returns NAs", {


### PR DESCRIPTION
Closes #25

A pretty comprehensive refactor of the internal representation to avoid redundancy in `sec`/`secfrac` and `tzhour`/`tzmin`.

Lots of coercion, formatting and tests were reworked to support this.