### PR TITLE
Revise pmax/pmin

### DIFF
--- a/R/class_partial_time_min_max.R
+++ b/R/class_partial_time_min_max.R
@@ -64,8 +64,6 @@ min.partial_time <- function(..., na.rm = FALSE, na.warn = TRUE) {
 
 
 pmin_pmax_handler <- function(f, ..., na.rm = FALSE) {
-  # TODO:
-  #   handle case where x's are all length 1
   dots <- lapply(list(...), as.parttime)
 
   max_nrows <- max(dot_nrow <- sapply(dots, nrow))
@@ -73,45 +71,14 @@ pmin_pmax_handler <- function(f, ..., na.rm = FALSE) {
     warning("an argument will be fractionally recycled")
 
   dots <- lapply(dots, rep, length.out = max_nrows)
+  out <- rep_len(parttime(NA), max_nrows)
 
-  x <- lapply(dots, vctrs::field, "pttm_mat")
-  x <- if (length(x) == 1) x[[1]]
-  else pmin_pmax_parttime_matrix_list(f, x, na.rm = na.rm)
-
-  colnames(x) <- colnames(vctrs::field(dots[[1]], "pttm_mat"))
-  out <- rep(parttime(NA), length.out = nrow(x))
-  vctrs::field(out, "pttm_mat") <- x
-  out <- propagate_na(out, keep_tz = TRUE)
-  out
-}
-
-
-
-pmin_pmax_parttime_matrix_list <- function(f, x, na.rm = FALSE) {
-  dim_in <- dim(x[[1]])
-  colnames_in <- colnames(x[[1]])
-  rownames_in <- rownames(x[[1]])
-
-  x <- array(do.call(rbind, x), dim = c(dim_in[[1]], length(x), dim_in[[2]]))
-
-  # work our way down time resolution scale, filtering down for max values
-  f_handler <- function(i) i == f(i, na.rm = na.rm) | (!na.rm & is.na(i))
-  max_mask <- array(TRUE, dim = dim(x)[c(1, 2)])
-
-  for (i in seq_len(dim(x)[[3]])) {
-    x[, ,i][!max_mask] <- NA
-    max_x_i <- x[, , i, drop = FALSE]
-    if (sum(is.na(max_x_i)) == prod(dim(max_x_i))) break
-    max_x_i[rowSums(is.na(max_x_i)) == ncol(max_x_i), , 1] <- 0
-    max_x_i <- t(apply(max_x_i, 1, f_handler))
-    max_mask <- max_mask & max_x_i
+  for (i in seq_along(out)) {
+    vals <- lapply(dots, `[[`, i)
+    out[[i]] <- do.call(f, append(vals, list(na.rm = na.rm, na.warn = FALSE)))
   }
 
-  # coerce back into standard matrix in long form and subset based on mask
-  x <- matrix(x, ncol = dim_in[[2]])
-  x <- x[seq_len(dim_in[[1]]) + dim_in[[1]] * (apply(max_mask, 1, Position, f = isTRUE) - 1), , drop = FALSE]
-  colnames(x) <- colnames_in
-  x
+  out
 }
 
 

--- a/tests/testthat/test_partial_time_comparisons.R
+++ b/tests/testthat/test_partial_time_comparisons.R
@@ -1,0 +1,65 @@
+test_that("partial times can be compared with `min`, `max`", {
+  x <- as.parttime("2017")
+  y <- as.parttime("2017-01")
+  expect_equal(max(x, y), as.parttime("2017"))
+
+  x <- as.parttime("2017")
+  y <- as.parttime("2017-01-01T01:02:03")
+  expect_equal(max(x, y), as.parttime("2017"))
+
+  x <- as.parttime("2017-03-04")
+  y <- as.parttime("2017-01-01T01:02:03")
+  expect_equal(max(x, y), as.parttime("2017-03-04"))
+})
+
+test_that("partial times extrema ignores missing values when na.rm is TRUE", {
+  x <- as.parttime("2017")
+  y <- as.parttime("2017-01")
+  expect_equal(suppressWarnings(max(x, y, na.rm = TRUE)), as.parttime("2017-01"))
+
+  x <- as.parttime("2017")
+  y <- as.parttime("2017-01-01T01:02:03")
+  expect_equal(suppressWarnings(max(x, y, na.rm = TRUE)), as.parttime("2017-01-01T01:02:03"))
+
+  x <- as.parttime("2017-03-04")
+  y <- as.parttime("2017-01-01T01:02:03")
+  expect_equal(suppressWarnings(max(x, y, na.rm = TRUE)), as.parttime("2017-03-04"))
+})
+
+test_that("partial times extrema with na.rm TRUE warns unless na.warn is FALSE", {
+  x <- as.parttime("2017")
+  y <- as.parttime("2017-01")
+  expect_warning(max(x, y, na.rm = TRUE))
+  expect_silent(max(x, y, na.rm = TRUE, na.warn = FALSE))
+
+  x <- as.parttime("2017")
+  y <- as.parttime("2017-01-01T01:02")
+  expect_warning(max(x, y, na.rm = TRUE))
+  expect_silent(max(x, y, na.rm = TRUE, na.warn = FALSE))
+})
+
+test_that("partial times extrema with na.rm TRUE does not warn when a value exists for all fields", {
+  withr::with_options(list(parttime.assume_tz_offset = 0L), {
+    x <- as.parttime("2017")
+    y <- as.parttime("2017-01-01T01:02:30")
+    expect_silent(max(x, y, na.rm = TRUE))
+    expect_silent(max(x, y, na.rm = TRUE, na.warn = FALSE))
+  })
+})
+
+
+
+test_that("partial times vectorized extrema", {
+  x <- as.parttime(c("2017", "2017-01-01"))
+  y <- as.parttime(c("2017-01", "2017-01"))
+
+  expect_equal(pmax(x, y), as.parttime(c("2017", "2017-01")))
+  expect_equal(pmax(x, y, na.rm = TRUE), as.parttime(c("2017-01", "2017-01-01")))
+
+  x <- as.parttime(c("2017", "2017-01-01"))
+  y <- as.parttime(c("2017-01", "2017-01"))
+  z <- as.parttime(c("2017-012", "2017-02-01"))
+
+  expect_equal(pmax(x, y, z), as.parttime(c("2017", "2017-02-01")))
+  expect_equal(pmax(x, y, z, na.rm = TRUE), as.parttime(c("2017-012", "2017-02-01")))
+})


### PR DESCRIPTION
Previous `pmin`/`pmax` was a bit complex

Since I didn't really have good metrics to back up the need for a complicated implementation, and because this behavior doesn't seem to be in high demand, I opted to simplify the implementation. It now falls back to a simple iteration applying an element-wise max. 

Until there's need for better performance, I think this should suffice and be more maintainable. 