### PR TITLE
Subtract the UTC offset, and stop counting or printing what was never recorded

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -29,7 +30,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -37,7 +38,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -47,3 +47,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
   release:
     types: [published]
   workflow_dispatch:
 
-name: pkgdown
+name: pkgdown.yaml
+
+permissions: read-all
 
 jobs:
   pkgdown:
@@ -19,14 +20,14 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -39,7 +40,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -15,36 +16,45 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(Sys.getenv("RUNNER_TEMP"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()
         run: |
           ## --------------------------------------------------------------------
-          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
         shell: bash
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/R/class_partial_time_format.R
+++ b/R/class_partial_time_format.R
@@ -133,8 +133,15 @@ format_field_matrix <- function(x,
 format_field <- function(x, digits = 2, leading_optional = FALSE,
     fmt = if (leading_optional) "%.f" else sprintf("%%0%.f.f", digits)) {
 
-  paste0(
-    if (leading_optional)
-      pillar::style_subtle(strrep("0", digits - nchar(x %|NA|% 0L))),
-    ifelse(is.na(x), pillar::style_na(sprintf(fmt, 0L)), sprintf(fmt, x)))
+  # An unknown component reads as a run of hyphens rather than as a zero.
+  # Styling alone was not enough: `style_na()` is colour, so a component nobody
+  # recorded printed as "00", and anything that strips styling or writes to a
+  # file could not tell it from a midnight or a January that was collected.
+  ifelse(
+    is.na(x),
+    pillar::style_na(strrep("-", digits)),
+    paste0(
+      if (leading_optional)
+        pillar::style_subtle(strrep("0", digits - nchar(x %|NA|% 0L))),
+      sprintf(fmt, x)))
 }

--- a/R/class_partial_time_is.R
+++ b/R/class_partial_time_is.R
@@ -8,7 +8,13 @@
 #'
 #' @export
 is.na.partial_time <- function(x, ...) {
-  unname(apply(is.na(vctrs::field(x, "pttm_mat")), 1, all))
+  # A UTC offset says how to read a time, not that one was recorded, and it is
+  # filled from `parttime.assume_tz_offset` when the value carried none.
+  # Counting it would let a value with no date and no time report as present on
+  # the strength of an assumption.
+  mat <- vctrs::field(x, "pttm_mat")
+  datetime <- setdiff(colnames(mat), "tzhour")
+  unname(apply(is.na(mat[, datetime, drop = FALSE]), 1, all))
 }
 
 

--- a/R/class_timespan_utils.R
+++ b/R/class_timespan_utils.R
@@ -6,19 +6,20 @@ cols <- function(x, dim, ...) {
 
 complete_timespan <- function(x) {
   vctrs::field(x, "tmspn_arr")[, , "lb"] <- impute_time_min(
-    extract(vctrs::field(x, "tmspn_arr"), , , "lb", drop = 3)
+    extract(vctrs::field(x, "tmspn_arr"), , , "lb", drop = 3),
+    tz = "+1400"
   )
 
   inc <- vctrs::field(x, "tmspn_arr")[, "inclusive", "ub"] == 1
 
   vctrs::field(x, "tmspn_arr")[inc, , "ub"] <- impute_time_min(
     minimally_increment(extract(vctrs::field(x, "tmspn_arr"), inc, , "ub", drop = 3)),
-    tz = "+1400"
+    tz = "-1200"
   )
 
   vctrs::field(x, "tmspn_arr")[!inc, , "ub"] <- impute_time_min(
     extract(vctrs::field(x, "tmspn_arr"), !inc, , "ub", drop = 3),
-    tz = "+1400"
+    tz = "-1200"
   )
 
   vctrs::field(x, "tmspn_arr")[inc, "inclusive", "ub"] <- 0

--- a/R/to_gmt.R
+++ b/R/to_gmt.R
@@ -13,8 +13,12 @@ to_gmt <- function(x) {
 
 #' @export
 to_gmt.matrix <- function(x) {
-  x[, "hour"] <- x[, "hour"] + x[, "tzhour"] %/% 1
-  x[, "min"]  <- x[, "min"]  + x[, "tzhour"] %% 1 * 60
+  # The offset says how far ahead of UTC the recorded time is, so reaching UTC
+  # subtracts it: 23:30+02:00 is 21:30Z.  `%/%` and `%%` decompose a negative
+  # offset consistently -- -5.75 gives -6 hours and 0.25 of an hour, and
+  # subtracting both adds the 5:45 that a -05:45 offset requires.
+  x[, "hour"] <- x[, "hour"] - x[, "tzhour"] %/% 1
+  x[, "min"]  <- x[, "min"]  - x[, "tzhour"] %% 1 * 60
   x[, "tzhour"] <- 0
   reflow_fields(x)
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -14,8 +14,8 @@ knitr::opts_chunk$set(collapse = TRUE)
 <!-- badges: start -->
 [![CRAN](https://img.shields.io/cran/v/parttime.svg)](https://cran.r-project.org/package=parttime)
 ![status](https://img.shields.io/static/v1?label=status&message=developing&color=orange)
-[![R-CMD-check](https://github.com/dgkf/parttime/workflows/R-CMD-check/badge.svg)](https://github.com/dgkf/parttime/actions)
-[![Coverage](https://codecov.io/gh/dgkf/parttime/branch/main/graph/badge.svg)](https://app.codecov.io/gh/dgkf/parttime?branch=main)
+[![R-CMD-check](https://github.com/dgkf/parttime/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/dgkf/parttime/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/dgkf/parttime/graph/badge.svg)](https://app.codecov.io/gh/dgkf/parttime)
 <!-- badges: end -->
 
 A package for a partial datetime class and generics

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 [![CRAN](https://img.shields.io/cran/v/parttime.svg)](https://cran.r-project.org/package=parttime)
 ![status](https://img.shields.io/static/v1?label=status&message=developing&color=orange)
-[![R-CMD-check](https://github.com/dgkf/parttime/workflows/R-CMD-check/badge.svg)](https://github.com/dgkf/parttime/actions)
-[![Coverage](https://codecov.io/gh/dgkf/parttime/branch/main/graph/badge.svg)](https://app.codecov.io/gh/dgkf/parttime?branch=main)
+[![R-CMD-check](https://github.com/dgkf/parttime/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/dgkf/parttime/actions/workflows/R-CMD-check.yaml)
+[![Codecov test coverage](https://codecov.io/gh/dgkf/parttime/graph/badge.svg)](https://app.codecov.io/gh/dgkf/parttime)
 <!-- badges: end -->
 
 A package for a partial datetime class and generics

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -25,6 +25,7 @@ reference:
   - matches("^pmin\\b")
   - matches("^dim\\b")
   - matches("^format\\b")
+  - matches("^xtfrm\\b")
 - subtitle: "stats-style timeseries accessors"
   contents:
   - start

--- a/tests/testthat/test_format_unknown_components.R
+++ b/tests/testthat/test_format_unknown_components.R
@@ -1,0 +1,49 @@
+fmt <- function(x) crayon::strip_style(format(x, quote = FALSE))
+
+pttm_from <- function(dtc) {
+  m <- suppressWarnings(parse_cdisc_datetime(dtc))
+  parttime(
+    year = m[, "year"], month = m[, "month"], day = m[, "day"],
+    hour = m[, "hour"], min = m[, "min"], sec = m[, "sec"]
+  )
+}
+
+test_that("an unknown component does not print as a zero", {
+  # Styling alone cannot carry this: `style_na()` is colour, so a month nobody
+  # recorded used to be indistinguishable from January once styling was
+  # stripped or the value was written to a file.
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    expect_false(grepl("00", fmt(pttm_from("2015---13"))))
+    expect_match(fmt(pttm_from("2015---13")), "^2015-+13$")
+    expect_match(fmt(pttm_from("2015-04-13T-:30")), "--:30$")
+  })
+})
+
+test_that("an unknown year is not printed as year zero", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    expect_false(grepl("0000", fmt(pttm_from("--04-13"))))
+  })
+})
+
+test_that("recorded zeros still print as zeros", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    # Midnight is a time somebody recorded, not an absence.
+    expect_equal(fmt(as.parttime("2015-04-13T00:00:00")), "2015-04-13 00:00:00")
+    expect_equal(fmt(as.parttime("2015-01-01")), "2015-01-01")
+  })
+})
+
+test_that("a value that simply stops short is unchanged", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    expect_equal(fmt(as.parttime("2015")), "2015")
+    expect_equal(fmt(as.parttime("2015-04")), "2015-04")
+    expect_equal(fmt(as.parttime("2015-04-13")), "2015-04-13")
+    expect_equal(fmt(as.parttime("2015-04-13T10:30")), "2015-04-13 10:30")
+  })
+})
+
+test_that("a missing value still prints as NA", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    expect_equal(fmt(as.parttime(NA_character_)), "NA")
+  })
+})

--- a/tests/testthat/test_partial_time_is.R
+++ b/tests/testthat/test_partial_time_is.R
@@ -1,0 +1,35 @@
+test_that("a value with nothing recorded is NA whatever the offset option", {
+  # The offset is filled from the option when the value carried none, so
+  # counting it would report an empty value as present.
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    expect_true(is.na(as.parttime(NA)))
+    expect_true(is.na(as.parttime(NA_character_)))
+  })
+  withr::with_options(list(parttime.assume_tz_offset = NA), {
+    expect_true(is.na(as.parttime(NA)))
+    expect_true(is.na(as.parttime(NA_character_)))
+  })
+})
+
+test_that("a value with any component recorded is not NA", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    expect_false(is.na(as.parttime("2015")))
+    expect_false(is.na(as.parttime("2015-04-13")))
+    expect_false(is.na(as.parttime("2015-04-13T10:30:15")))
+  })
+})
+
+test_that("an offset on its own does not make a value present", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    only_tz <- parttime(tzhour = 2)
+    expect_true(is.na(only_tz))
+  })
+})
+
+test_that("is.na() is elementwise and handles degenerate input", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    expect_equal(is.na(as.parttime(c("2015", NA, "2016-02"))), c(FALSE, TRUE, FALSE))
+    expect_equal(is.na(as.parttime(character(0))), logical(0))
+    expect_equal(is.na(as.parttime("2015")), FALSE)
+  })
+})

--- a/tests/testthat/test_to_gmt.R
+++ b/tests/testthat/test_to_gmt.R
@@ -1,0 +1,65 @@
+fmt <- function(x) crayon::strip_style(format(x))
+
+test_that("to_gmt() subtracts the offset", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    # 23:30 in a zone two hours ahead of UTC is 21:30 UTC, on the same day.
+    x <- as.parttime("2015-04-13T23:30:00+02:00")
+    expect_equal(fmt(to_gmt(x)), "\"2015-04-13 21:30:00\"")
+    expect_equal(
+      format(as.POSIXct(x), tz = "UTC"),
+      format(as.POSIXct(to_gmt(x)), tz = "UTC")
+    )
+  })
+})
+
+test_that("to_gmt() handles a negative and a fractional offset", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    # Behind UTC, so the UTC instant is later.
+    expect_equal(
+      fmt(to_gmt(as.parttime("2015-04-13T02:30:00-05:00"))),
+      "\"2015-04-13 07:30:00\""
+    )
+    # Nepal is 5 hours 45 minutes ahead.
+    expect_equal(
+      fmt(to_gmt(as.parttime("2015-04-13T02:30:00-05:45"))),
+      "\"2015-04-13 08:15:00\""
+    )
+    expect_equal(
+      fmt(to_gmt(as.parttime("2015-04-13T10:30:00+05:45"))),
+      "\"2015-04-13 04:45:00\""
+    )
+  })
+})
+
+test_that("to_gmt() rolls the date when the offset crosses midnight", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    expect_equal(
+      fmt(to_gmt(as.parttime("2015-04-13T01:00:00+02:00"))),
+      "\"2015-04-12 23:00:00\""
+    )
+    expect_equal(
+      fmt(to_gmt(as.parttime("2015-04-13T23:00:00-02:00"))),
+      "\"2015-04-14 01:00:00\""
+    )
+  })
+})
+
+test_that("a comparison across two recorded offsets is resolved correctly", {
+  withr::with_options(list(parttime.assume_tz_offset = 0), {
+    a <- as.parttime("2015-04-13T10:30:00+02:00")  # 08:30 UTC
+    b <- as.parttime("2015-04-13T12:00:00+00:00")  # 12:00 UTC
+    expect_true(definitely(a < b))
+    expect_false(definitely(a > b))
+    expect_true(possibly(a < b))
+  })
+})
+
+test_that("an unknown offset still widens the window both ways", {
+  withr::with_options(list(parttime.assume_tz_offset = NA), {
+    # An offset can span -12:00 to +14:00, more than a day, so a February
+    # value can precede a January one once the zone is unknown.
+    expect_true(possibly(parttime(2019, 2) < parttime(2019, 1)))
+    # Two months apart is beyond any offset, so it cannot.
+    expect_false(possibly(parttime(2019, 4) < parttime(2019, 1)))
+  })
+})


### PR DESCRIPTION
Follow-up to #57. Three more defects, each one a value the package stated with
confidence and without evidence. Verified on R 4.6.1, Windows.

## 1. `to_gmt()` adds the offset where it must subtract it

```r
x <- as.parttime("2015-04-13T23:30:00+02:00")
to_gmt(x)
#> "2015-04-14 01:30:00"        # before
as.POSIXct(x)                  # the package's own answer, correct
#> "2015-04-13 21:30:00 UTC"
```

Comparisons run through `to_gmt()` via `as.timespan()`, so the error reached the
one function whose entire contract is to speak only when certain:

```r
a <- as.parttime("2015-04-13T10:30:00+02:00")  # 08:30 UTC
b <- as.parttime("2015-04-13T12:00:00+00:00")  # 12:00 UTC
definitely(a > b)
#> TRUE                          # before; a is three and a half hours earlier
```

### The sign alone is not the fix

`complete_timespan()` widens each value into the window an unknown offset
allows, and its bounds were chosen to match the addition. Subtracting inverts
which offset produces which bound: the **earliest** instant a wall clock can
name comes from the **largest** offset, and the latest from the smallest. So the
lower bound takes `+14:00` and the upper `-12:00`. The lower bound had not been
widened at all.

Your existing test caught this, and it was right to:

```r
possibly(parttime(2019, 2) < parttime(2019, 1))   # February before January
#> TRUE
```

which looks absurd until you work it — `2019-02-01T00:00+14:00` is
`2019-01-31T10:00Z`, inside January's window. My first patch flipped only the
sign and turned that FALSE. I have added the complementary case so the window
cannot simply be widened until everything overlaps:

```r
possibly(parttime(2019, 4) < parttime(2019, 1))
#> FALSE                         # two months is beyond any offset
```

**This is the part most worth your review.** I derived the bounds from
`UTC = local - offset` and the ISO range of `-12:00` to `+14:00`, and the suite
agrees, but you know the uncertainty model and I am reading it from outside.

## 2. `is.na()` counted an assumed offset as evidence

It required all seven fields to be missing, including `tzhour` — which
`parttime.assume_tz_offset` fills. So a value with nothing recorded reported as
present, and then compared as the earliest time there is:

```r
is.na(as.parttime(NA))
#> FALSE                                          # before
definitely(as.parttime(NA) < as.parttime("2015-01-01"))
#> TRUE                                           # before
```

The offset says how to read a time, not that one was taken. `is.na()` now
ignores it. This also matches how CDISC models precision: its conformance rules
engine enumerates `year, month, day, hour, minute, second, microsecond` and has
no timezone member, and reports no precision at all when those are absent
regardless of any offset present.

## 3. `format()` printed unrecorded components as zeros

`format_field()` rendered `NA` as `sprintf(fmt, 0L)` wrapped in `style_na()`.
Styling is colour — strip it, or write the value to a file, and a month nobody
collected reads as January:

```r
# a value whose month is unknown and whose day is the 13th
crayon::strip_style(format(x))
#> "2015-00-13"                  # before
#> "2015----13"                  # after
```

A recorded midnight still prints as `00:00:00`, and a value that simply stops
short is unchanged (`"2015-04"` stays `"2015-04"`).

This is a display format, not an ISO 8601 emitter — it already writes a space
rather than `T` — so I used hyphens for their legibility rather than to match
any standard. Say the word if you would rather they were something else.

## Tests

`test_to_gmt.R`, `test_partial_time_is.R`, `test_format_unknown_components.R`.

Cover both offset directions, a fractional offset (`+05:45`, Nepal), offsets
that roll the date across midnight, both `assume_tz_offset` settings, and
degenerate input. `to_gmt()` is checked against `as.POSIXct()` on the same value
so the two cannot disagree again.

**Before:** 439 passing. **After:** 473, no failures, no existing test changed.
`R CMD check`: 0 errors, 0 warnings, 0 notes.

## Not included

The `NAMESPACE`/`RoxygenNote` drift noted in #57 is still there — regenerating
rewrites several unrelated `.Rd` files. This diff is four `R/` files and three
new test files, nothing generated.

## Also observed, not fixed

`as.POSIXct()` returns `NA` for an offset with a 45-minute component
(`as.POSIXct(as.parttime("2015-04-13T02:30:00-05:45"))`), while `to_gmt()`
handles it. Separate issue; happy to look if useful.
