### PR TITLE
Print an unknown datetime component as `?` rather than as zero

### DIFF
--- a/R/class_partial_time_format.R
+++ b/R/class_partial_time_format.R
@@ -133,8 +133,14 @@ format_field_matrix <- function(x,
 format_field <- function(x, digits = 2, leading_optional = FALSE,
     fmt = if (leading_optional) "%.f" else sprintf("%%0%.f.f", digits)) {
 
-  paste0(
-    if (leading_optional)
-      pillar::style_subtle(strrep("0", digits - nchar(x %|NA|% 0L))),
-    ifelse(is.na(x), pillar::style_na(sprintf(fmt, 0L)), sprintf(fmt, x)))
+  # A zero here was indistinguishable from a collected midnight or January
+  # once `style_na()`'s colour was stripped or the value reached a file.  `?`
+  # rather than `-`, which already delimits the date.
+  ifelse(
+    is.na(x),
+    pillar::style_na(strrep("?", digits)),
+    paste0(
+      if (leading_optional)
+        pillar::style_subtle(strrep("0", digits - nchar(x %|NA|% 0L))),
+      sprintf(fmt, x)))
 }

--- a/tests/testthat/test_format_unknown_components.R
+++ b/tests/testthat/test_format_unknown_components.R
@@ -1,0 +1,32 @@
+withr::local_options(parttime.assume_tz_offset = 0, .local_envir = teardown_env())
+
+test_that("an unknown component is not printed as a zero", {
+  # `style_na()` is colour, so a component nobody recorded used to be
+  # indistinguishable from a collected one wherever styling was stripped.
+  m <- suppressWarnings(
+    parse_cdisc_datetime(c("2015---13", "--04-13", "2015-04-13T-:30"))
+  )
+  x <- parttime(
+    year = m[, "year"], month = m[, "month"], day = m[, "day"],
+    hour = m[, "hour"], min = m[, "min"], sec = m[, "sec"]
+  )
+  expect_equal(
+    crayon::strip_style(format(x, quote = FALSE)),
+    c("2015-??-13", "????-04-13", "2015-04-13 ??:30")
+  )
+})
+
+test_that("collected values are printed as they were", {
+  # The other half: a midnight and a January are values, not absences, and a
+  # value that stops short keeps stopping short.
+  same <- c("2015-04-13 00:00:00", "2015-01-01", "2015", "2015-04",
+            "2015-04-13", "2015-04-13 10:30")
+  expect_equal(
+    crayon::strip_style(format(as.parttime(sub(" ", "T", same)), quote = FALSE)),
+    same
+  )
+  expect_equal(
+    crayon::strip_style(format(as.parttime(NA_character_), quote = FALSE)),
+    "NA"
+  )
+})


### PR DESCRIPTION
Fix #47

`format_field()` renders a missing component as `sprintf(fmt, 0)` wrapped in
`style_na()`. The styling makes it legible in a colour terminal, but the string
itself says zero — so wherever the colour does not survive, a component nobody
recorded is indistinguishable from one that was collected:

```r
x <- as.parttime("2015---13")          # month unknown, day 13
crayon::strip_style(format(x))
#> "2015-00-13"                         # before
#> "2015-??-13"                         # after
```

The matrix underneath is correct throughout — `vctrs::field(x, "pttm_mat")`
holds `NA` for the month. Only the rendering invents the zero.

| input | before | after |
|---|---|---|
| `2015---13` | `2015-00-13` | `2015-??-13` |
| `--04-13` | `0000-04-13` | `????-04-13` |
| `2015-04-13T-:30` | `2015-04-13 00:30` | `2015-04-13 ??:30` |

Anything that strips styling sees the old output: a write to file, a log, a
knitted document, and this package's own tests, which call
`crayon::strip_style()` around `format()`.

## `?` rather than `-`

`-` already delimits the date, so `2015----13` reads ambiguously. `?` does not
collide with any separator this format uses.

## Not changed

Values that were collected print as before — a recorded midnight is still
`00:00:00`, and a value that simply stops short still stops short. The new test
file pins both directions, so a future change cannot quieten the placeholder by
also swallowing real zeros.

## Checks

`R CMD check`: 0 errors, 0 warnings, 0 notes. 444 tests passing.

---

Prepared with Claude Opus 5.