### PR TITLE
Do not count an assumed UTC offset as a recorded value

### DIFF
--- a/R/class_partial_time_is.R
+++ b/R/class_partial_time_is.R
@@ -8,7 +8,13 @@
 #'
 #' @export
 is.na.partial_time <- function(x, ...) {
-  unname(apply(is.na(vctrs::field(x, "pttm_mat")), 1, all))
+  # A UTC offset says how to read a time, not that one was recorded, and it is
+  # filled from `parttime.assume_tz_offset` when the value carried none.
+  # Counting it would let a value with no date and no time report as present on
+  # the strength of an assumption.
+  mat <- vctrs::field(x, "pttm_mat")
+  datetime <- setdiff(colnames(mat), "tzhour")
+  unname(apply(is.na(mat[, datetime, drop = FALSE]), 1, all))
 }
 
 

--- a/tests/testthat/test_partial_time_is.R
+++ b/tests/testthat/test_partial_time_is.R
@@ -1,0 +1,21 @@
+test_that("the UTC offset does not count towards a value being present", {
+  # `parttime.assume_tz_offset` fills the offset when the value carried none,
+  # so counting it reported an empty value as present whatever the option said.
+  for (opt in list(0, NA)) {
+    withr::local_options(parttime.assume_tz_offset = opt)
+    expect_equal(
+      is.na(as.parttime(c(NA, "2015", "2015-04-13", "2015-04-13T10:30:15"))),
+      c(TRUE, FALSE, FALSE, FALSE)
+    )
+    # A logical `NA` is cast by another path, and an offset with no date or
+    # time behind it is the case the fix is named for.
+    expect_true(is.na(as.parttime(NA)))
+    expect_true(is.na(parttime(tzhour = 2)))
+  }
+})
+
+test_that("is.na() handles degenerate input", {
+  withr::local_options(parttime.assume_tz_offset = 0)
+  expect_equal(is.na(as.parttime(character(0))), logical(0))
+  expect_equal(is.na(as.parttime("2015")), FALSE)
+})


### PR DESCRIPTION
`is.na.partial_time` requires all seven fields to be missing, including
`tzhour`. But `parttime.assume_tz_offset` *fills* that field when the value
carried no offset of its own, so a value with no date and no time reports
itself as present on the strength of an assumption — and then compares as the
earliest time there is:

```r
options(parttime.assume_tz_offset = 0)

is.na(as.parttime(NA))
#> FALSE

definitely(as.parttime(NA) < as.parttime("2015-01-01"))
#> TRUE
```

`as.parttime(NA_character_)` is unaffected, so this only bites the logical-`NA`
path — which is what an all-missing column in a data frame gives you.

## The change

Missingness is read from the six date and time components; `tzhour` is
excluded. An offset says how to read a time, not that one was taken.

```r
mat <- vctrs::field(x, "pttm_mat")
datetime <- setdiff(colnames(mat), "tzhour")
unname(apply(is.na(mat[, datetime, drop = FALSE]), 1, all))
```

Reading the column names rather than dropping a fixed index means a component
added to `pttm_mat` later is counted without anyone having to remember.

## Prior art for the distinction

CDISC's conformance rules engine draws the same line: its precision enum is
`year, month, day, hour, minute, second, microsecond` with no timezone member,
and it reports no precision at all when those are absent regardless of any
offset present.

## Checks

Verified both directions — `is.na(as.parttime(NA))` is `FALSE` on `main` and
`TRUE` with the change. The test covers both `parttime.assume_tz_offset`
settings, a value carrying nothing but an offset, and empty input.

`R CMD check`: 0 errors, 0 warnings, 0 notes. 447 tests passing.

---

Prepared with Claude Opus 5.