### PR TITLE
Subtract the UTC offset when converting to GMT

### DIFF
--- a/R/class_timespan_utils.R
+++ b/R/class_timespan_utils.R
@@ -6,19 +6,20 @@ cols <- function(x, dim, ...) {
 
 complete_timespan <- function(x) {
   vctrs::field(x, "tmspn_arr")[, , "lb"] <- impute_time_min(
-    extract(vctrs::field(x, "tmspn_arr"), , , "lb", drop = 3)
+    extract(vctrs::field(x, "tmspn_arr"), , , "lb", drop = 3),
+    tz = "+1400"
   )
 
   inc <- vctrs::field(x, "tmspn_arr")[, "inclusive", "ub"] == 1
 
   vctrs::field(x, "tmspn_arr")[inc, , "ub"] <- impute_time_min(
     minimally_increment(extract(vctrs::field(x, "tmspn_arr"), inc, , "ub", drop = 3)),
-    tz = "+1400"
+    tz = "-1200"
   )
 
   vctrs::field(x, "tmspn_arr")[!inc, , "ub"] <- impute_time_min(
     extract(vctrs::field(x, "tmspn_arr"), !inc, , "ub", drop = 3),
-    tz = "+1400"
+    tz = "-1200"
   )
 
   vctrs::field(x, "tmspn_arr")[inc, "inclusive", "ub"] <- 0

--- a/R/to_gmt.R
+++ b/R/to_gmt.R
@@ -13,8 +13,12 @@ to_gmt <- function(x) {
 
 #' @export
 to_gmt.matrix <- function(x) {
-  x[, "hour"] <- x[, "hour"] + x[, "tzhour"] %/% 1
-  x[, "min"]  <- x[, "min"]  + x[, "tzhour"] %% 1 * 60
+  # The offset says how far ahead of UTC the recorded time is, so reaching UTC
+  # subtracts it: 23:30+02:00 is 21:30Z.  `%/%` and `%%` decompose a negative
+  # offset consistently -- -5.75 gives -6 hours and 0.25 of an hour, and
+  # subtracting both adds the 5:45 that a -05:45 offset requires.
+  x[, "hour"] <- x[, "hour"] - x[, "tzhour"] %/% 1
+  x[, "min"]  <- x[, "min"]  - x[, "tzhour"] %% 1 * 60
   x[, "tzhour"] <- 0
   reflow_fields(x)
 }

--- a/tests/testthat/test_to_gmt.R
+++ b/tests/testthat/test_to_gmt.R
@@ -1,0 +1,39 @@
+withr::local_options(parttime.assume_tz_offset = 0, .local_envir = teardown_env())
+
+test_that("to_gmt() subtracts the offset", {
+  # UTC = local - offset, so a zone ahead of UTC reads earlier and one behind
+  # reads later, and the date follows when that crosses midnight.
+  cases <- c(
+    "2015-04-13T23:30:00+02:00" = "2015-04-13 21:30:00",
+    "2015-04-13T02:30:00-05:00" = "2015-04-13 07:30:00",
+    "2015-04-13T02:30:00-05:45" = "2015-04-13 08:15:00",  # Nepal, off the hour
+    "2015-04-13T01:00:00+02:00" = "2015-04-12 23:00:00",
+    "2015-04-13T23:00:00-02:00" = "2015-04-14 01:00:00"
+  )
+  expect_equal(
+    crayon::strip_style(format(to_gmt(as.parttime(names(cases))), quote = FALSE)),
+    unname(cases)
+  )
+})
+
+test_that("to_gmt() agrees with as.POSIXct()", {
+  x <- as.parttime("2015-04-13T23:30:00+02:00")
+  expect_equal(as.POSIXct(to_gmt(x)), as.POSIXct(x))
+})
+
+test_that("a comparison across two recorded offsets is resolved", {
+  a <- as.parttime("2015-04-13T10:30:00+02:00")  # 08:30 UTC
+  b <- as.parttime("2015-04-13T12:00:00+00:00")  # 12:00 UTC
+  expect_equal(c(definitely(a < b), definitely(a > b)), c(TRUE, FALSE))
+})
+
+test_that("an unknown offset widens the window by its full range", {
+  # An offset spans -12:00 to +14:00, more than a day, so February can precede
+  # January once the zone is unknown; two months apart is beyond any offset.
+  withr::local_options(parttime.assume_tz_offset = NA)
+  # Both sides are length two because comparison does not recycle.
+  expect_equal(
+    possibly(parttime(2019, c(2, 4)) < parttime(2019, c(1, 1))),
+    c(TRUE, FALSE)
+  )
+})


### PR DESCRIPTION
`to_gmt()` adds the offset where reaching UTC subtracts it, and the package
disagrees with itself about the result:

```r
x <- as.parttime("2015-04-13T23:30:00+02:00")

to_gmt(x)
#> "2015-04-14 01:30:00"        # before

as.POSIXct(x)
#> "2015-04-13 21:30:00 UTC"    # correct, and unchanged by this PR
```

Comparison runs through `to_gmt()` via `as.timespan()`, so the error reaches
the one function whose contract is to speak only when certain:

```r
a <- as.parttime("2015-04-13T10:30:00+02:00")  # 08:30 UTC
b <- as.parttime("2015-04-13T12:00:00+00:00")  # 12:00 UTC
definitely(a > b)
#> TRUE                          # before; a is three and a half hours earlier
```

## The sign alone is not the whole fix

This is the part worth your review, and it answers the question you raised on
#58.

`complete_timespan()` widens each value into the window an unknown offset
allows, by imputing its bounds at fixed offsets. Those constants were chosen to
match the addition, so subtracting inverts which offset yields which bound: the
**earliest** instant a wall clock can name comes from the **largest** offset,
and the latest from the smallest. The lower bound takes `+14:00`, the upper
`-12:00`. The lower bound had not been widened at all.

Your existing test is what caught the incomplete version:

```r
possibly(parttime(2019, 2) < parttime(2019, 1))   # February before January
#> TRUE
```

which is right — `2019-02-01T00:00+14:00` is `2019-01-31T10:00Z`, inside
January's window. Flipping only the sign turned it FALSE. A second case sits
beside it now so the window cannot simply be widened until everything overlaps:

```r
possibly(parttime(2019, 4) < parttime(2019, 1))   # two months apart
#> FALSE
```

I derived the bounds from `UTC = local - offset` and the ISO range `-12:00` to
`+14:00`, and the suite agrees — but you know the uncertainty model and I am
reading it from outside, so this is the change I would most like a second
opinion on.

## Checks

Verified both directions: `to_gmt()` on `23:30+02:00` gives `2015-04-14
01:30:00` on `main` and `2015-04-13 21:30:00` here. Cases cover positive,
negative and quarter-hour offsets (`-05:45`, Nepal) and both directions of
midnight crossing, and `to_gmt()` is checked against `as.POSIXct()` on the same
value so the two cannot diverge again.

`R CMD check`: 0 errors, 0 warnings, 0 notes. 443 tests passing.

---

Prepared with Claude Opus 5.